### PR TITLE
Remove master logging switch

### DIFF
--- a/OptiScaler/Config.cpp
+++ b/OptiScaler/Config.cpp
@@ -83,13 +83,7 @@ bool Config::Reload(std::filesystem::path iniPath)
 			RenderPresetUltraPerformance.reset();
 
 		// logging
-		LoggingEnabled = readBool("Log", "LoggingEnabled");
-
-		if (LoggingEnabled.value_or(true))
-			LogLevel = readInt("Log", "LogLevel");
-		else
-			LogLevel = spdlog::level::off;
-
+		LogLevel = readInt("Log", "LogLevel");
 		LogToConsole = readBool("Log", "LogToConsole");
 		LogToFile = readBool("Log", "LogToFile");
 		LogToNGX = readBool("Log", "LogToNGX");
@@ -461,7 +455,6 @@ bool Config::SaveIni()
 	ini.SetValue("Dx11withDx12", "DontUseNTShared", GetBoolValue(Instance()->DontUseNTShared).c_str());
 
 	// Logging
-	ini.SetValue("Log", "LoggingEnabled", GetBoolValue(Instance()->LoggingEnabled).c_str());
 	ini.SetValue("Log", "LogLevel", GetIntValue(Instance()->LogLevel).c_str());
 	ini.SetValue("Log", "LogToConsole", GetBoolValue(Instance()->LogToConsole).c_str());
 	ini.SetValue("Log", "LogToFile", GetBoolValue(Instance()->LogToFile).c_str());

--- a/OptiScaler/Config.h
+++ b/OptiScaler/Config.h
@@ -30,7 +30,6 @@ public:
 	std::optional<bool> DisplayResolution;
 
 	// Logging
-	std::optional<bool> LoggingEnabled;
 	std::optional<bool> LogToFile;
 	std::optional<bool> LogToConsole;
 	std::optional<bool> LogToNGX;

--- a/OptiScaler/Logger.cpp
+++ b/OptiScaler/Logger.cpp
@@ -58,7 +58,7 @@ void PrepareLogger()
 		if (spdlog::default_logger() != nullptr)
 			spdlog::default_logger().reset();
 
-		if (Config::Instance()->LoggingEnabled.value_or(true))
+		if (Config::Instance()->LogToConsole.value_or(false) || Config::Instance()->LogToFile.value_or(false) || Config::Instance()->LogToNGX.value_or(false))
 		{
 			if (Config::Instance()->OpenConsole.value_or(false))
 				InitializeConsole();

--- a/OptiScaler/imgui/imgui_common.h
+++ b/OptiScaler/imgui/imgui_common.h
@@ -1485,17 +1485,11 @@ public:
 					// LOGGING -----------------------------
 					ImGui::SeparatorText("Logging");
 
-					if (bool logging = Config::Instance()->LoggingEnabled.value_or(true); ImGui::Checkbox("Logging", &logging))
-					{
-						Config::Instance()->LoggingEnabled = logging;
+					if (Config::Instance()->LogToConsole.value_or(false) || Config::Instance()->LogToFile.value_or(false) || Config::Instance()->LogToNGX.value_or(false))
+						spdlog::default_logger()->set_level((spdlog::level::level_enum)Config::Instance()->LogLevel.value_or(2));
+					else
+						spdlog::default_logger()->set_level(spdlog::level::off);
 
-						if (logging)
-							spdlog::default_logger()->set_level((spdlog::level::level_enum)Config::Instance()->LogLevel.value_or(2));
-						else
-							spdlog::default_logger()->set_level(spdlog::level::off);
-					}
-
-					ImGui::SameLine(0.0f, 6.0f);
 					if (bool toFile = Config::Instance()->LogToFile.value_or(false); ImGui::Checkbox("To File", &toFile))
 					{
 						Config::Instance()->LogToFile = toFile;

--- a/nvngx.ini
+++ b/nvngx.ini
@@ -298,11 +298,7 @@ MotionSharpnessDebug=auto
 ; -------------------------------------------------------
 [Log]
 ; -------------------------------------------------------
-; Logging
-; true or false- Default (auto) is true
-LoggingEnabled=auto
-
-; Log file, if undefined log_xess_xxxx.log file in current folder
+; Log file, if undefined OptiScaler.log file in current folder
 ;LogFile=./OptiScaler.log
 
 ; Verbosity level of file logs


### PR DESCRIPTION
A master switch for logging is unnecessary given that this information can be extrapolated.
For a long time the LogEnabled setting was already set to true by default and removing it will make it less confusing for the end users. 