### PR TITLE
fix: add UseGenericAppIdWithDlss

### DIFF
--- a/OptiScaler/Config.cpp
+++ b/OptiScaler/Config.cpp
@@ -276,6 +276,8 @@ bool Config::Reload(std::filesystem::path iniPath)
 
             UsePrecompiledShaders = readBool("Hotfix", "UsePrecompiledShaders");
 
+            UseGenericAppIdWithDlss = readBool("Hotfix", "UseGenericAppIdWithDlss");
+
             ColorResourceBarrier = readInt("Hotfix", "ColorResourceBarrier");
             MVResourceBarrier = readInt("Hotfix", "MotionVectorResourceBarrier");
             DepthResourceBarrier = readInt("Hotfix", "DepthResourceBarrier");
@@ -565,6 +567,8 @@ bool Config::SaveIni()
         ini.SetValue("Hotfix", "SkipFirstFrames", GetIntValue(Instance()->SkipFirstFrames).c_str());
 
         ini.SetValue("Hotfix", "UsePrecompiledShaders", GetBoolValue(Instance()->UsePrecompiledShaders).c_str());
+
+        ini.SetValue("Hotfix", "UseGenericAppIdWithDlss", GetBoolValue(Instance()->UseGenericAppIdWithDlss).c_str());
 
         ini.SetValue("Hotfix", "ColorResourceBarrier", GetIntValue(Instance()->ColorResourceBarrier).c_str());
         ini.SetValue("Hotfix", "MotionVectorResourceBarrier", GetIntValue(Instance()->MVResourceBarrier).c_str());

--- a/OptiScaler/Config.h
+++ b/OptiScaler/Config.h
@@ -106,6 +106,8 @@ public:
 	
 	std::optional<bool> UsePrecompiledShaders;
 
+	std::optional<bool> UseGenericAppIdWithDlss;
+
 	std::optional<int32_t> ColorResourceBarrier;
 	std::optional<int32_t> MVResourceBarrier;
 	std::optional<int32_t> DepthResourceBarrier;

--- a/OptiScaler/NVNGX.cpp
+++ b/OptiScaler/NVNGX.cpp
@@ -107,16 +107,19 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_UpdateFeature(const NVSDK_NGX_Applicati
 	{
 		if (ApplicationId->IdentifierType == NVSDK_NGX_Application_Identifier_Type_Application_Id)
 		{
-			LOG_INFO("Update ApplicationId: {0:X}", ApplicationId->v.ApplicationId);
-			Config::Instance()->NVNGX_ApplicationId = ApplicationId->v.ApplicationId;
+			auto appId = Config::Instance()->UseGenericAppIdWithDlss.value_or(false) ? app_id_override : ApplicationId->v.ApplicationId;
+			LOG_INFO("Update ApplicationId: {0:X}", appId);
+			Config::Instance()->NVNGX_ApplicationId = appId;
 		}
 		else if (ApplicationId->IdentifierType == NVSDK_NGX_Application_Identifier_Type_Project_Id)
 		{
-			Config::Instance()->NVNGX_ProjectId = std::string(ApplicationId->v.ProjectDesc.ProjectId);
+			auto projectId = Config::Instance()->UseGenericAppIdWithDlss.value_or(false) ? project_id_override :
+				std::string(ApplicationId->v.ProjectDesc.ProjectId);
+			Config::Instance()->NVNGX_ProjectId = projectId;
 			Config::Instance()->NVNGX_Engine = ApplicationId->v.ProjectDesc.EngineType;
 			Config::Instance()->NVNGX_EngineVersion = std::string(ApplicationId->v.ProjectDesc.EngineVersion);
 
-			LOG_INFO("Update InProjectId: {0}", Config::Instance()->NVNGX_ProjectId);
+			LOG_INFO("Update InProjectId: {0}", projectId);
 			LOG_INFO("Update InEngineType: {0}", (int)Config::Instance()->NVNGX_Engine);
 			LOG_INFO("Update InEngineVersion: {0}", Config::Instance()->NVNGX_EngineVersion);
 		}

--- a/OptiScaler/NVNGX_DLSS_Dx11.cpp
+++ b/OptiScaler/NVNGX_DLSS_Dx11.cpp
@@ -34,6 +34,9 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_Init_Ext(unsigned long long InApp
 {
     if (Config::Instance()->DLSSEnabled.value_or(true) && !NVNGXProxy::IsDx11Inited())
     {
+        if (Config::Instance()->UseGenericAppIdWithDlss.value_or(false))
+            InApplicationId = app_id_override;
+
         if (NVNGXProxy::NVNGXModule() == nullptr)
             NVNGXProxy::InitNVNGX();
 
@@ -106,6 +109,9 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_Init(unsigned long long InApplica
 {
     if (Config::Instance()->DLSSEnabled.value_or(true) && !NVNGXProxy::IsDx11Inited())
     {
+        if (Config::Instance()->UseGenericAppIdWithDlss.value_or(false))
+            InApplicationId = app_id_override;
+
         if (NVNGXProxy::NVNGXModule() == nullptr)
             NVNGXProxy::InitNVNGX();
 
@@ -131,6 +137,9 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_Init_ProjectID(const char* InProj
 {
     if (Config::Instance()->DLSSEnabled.value_or(true) && !NVNGXProxy::IsDx11Inited())
     {
+        if (Config::Instance()->UseGenericAppIdWithDlss.value_or(false))
+            InProjectId = project_id_override;
+
         if (NVNGXProxy::NVNGXModule() == nullptr)
             NVNGXProxy::InitNVNGX();
 

--- a/OptiScaler/NVNGX_DLSS_Dx12.cpp
+++ b/OptiScaler/NVNGX_DLSS_Dx12.cpp
@@ -209,6 +209,9 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_Ext(unsigned long long InApp
 {
     LOG_FUNC();
 
+    if (Config::Instance()->UseGenericAppIdWithDlss.value_or(false))
+        InApplicationId = app_id_override;
+
     Config::Instance()->NVNGX_ApplicationId = InApplicationId;
     Config::Instance()->NVNGX_ApplicationDataPath = std::wstring(InApplicationDataPath);
     Config::Instance()->NVNGX_Version = InSDKVersion;
@@ -291,6 +294,9 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init(unsigned long long InApplica
 
     if (Config::Instance()->DLSSEnabled.value_or(true) && !NVNGXProxy::IsDx12Inited())
     {
+        if (Config::Instance()->UseGenericAppIdWithDlss.value_or(false))
+            InApplicationId = app_id_override;
+
         if (NVNGXProxy::NVNGXModule() == nullptr)
             NVNGXProxy::InitNVNGX();
 
@@ -319,6 +325,9 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_Init_ProjectID(const char* InProj
 
     if (Config::Instance()->DLSSEnabled.value_or(true) && !NVNGXProxy::IsDx12Inited())
     {
+        if (Config::Instance()->UseGenericAppIdWithDlss.value_or(false))
+            InProjectId = project_id_override;
+
         if (NVNGXProxy::NVNGXModule() == nullptr)
             NVNGXProxy::InitNVNGX();
 

--- a/OptiScaler/NVNGX_DLSS_Vk.cpp
+++ b/OptiScaler/NVNGX_DLSS_Vk.cpp
@@ -36,6 +36,9 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_VULKAN_Init_Ext(unsigned long long InAp
 
     if (Config::Instance()->DLSSEnabled.value_or(true) && !NVNGXProxy::IsVulkanInited())
     {
+        if (Config::Instance()->UseGenericAppIdWithDlss.value_or(false))
+            InApplicationId = app_id_override;
+
         if (NVNGXProxy::NVNGXModule() == nullptr)
             NVNGXProxy::InitNVNGX();
 
@@ -59,6 +62,9 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_VULKAN_Init_Ext2(unsigned long long InA
 
     if (Config::Instance()->DLSSEnabled.value_or(true) && !NVNGXProxy::IsVulkanInited())
     {
+        if (Config::Instance()->UseGenericAppIdWithDlss.value_or(false))
+            InApplicationId = app_id_override;
+
         if (NVNGXProxy::NVNGXModule() == nullptr)
             NVNGXProxy::InitNVNGX();
 
@@ -206,6 +212,9 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_VULKAN_Init(unsigned long long InApplic
 
     if (Config::Instance()->DLSSEnabled.value_or(true) && !NVNGXProxy::IsVulkanInited())
     {
+        if (Config::Instance()->UseGenericAppIdWithDlss.value_or(false))
+            InApplicationId = app_id_override;
+
         if (NVNGXProxy::NVNGXModule() == nullptr)
             NVNGXProxy::InitNVNGX();
 
@@ -230,6 +239,9 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_VULKAN_Init_ProjectID(const char* InPro
 
     if (Config::Instance()->DLSSEnabled.value_or(true) && !NVNGXProxy::IsVulkanInited())
     {
+        if (Config::Instance()->UseGenericAppIdWithDlss.value_or(false))
+            InProjectId = project_id_override;
+
         if (NVNGXProxy::NVNGXModule() == nullptr)
             NVNGXProxy::InitNVNGX();
 

--- a/OptiScaler/NVNGX_Proxy.h
+++ b/OptiScaler/NVNGX_Proxy.h
@@ -11,6 +11,9 @@
 #include <filesystem>
 #include "detours/detours.h"
 
+inline const char* project_id_override = "24480451-f00d-face-1304-0308dabad187";
+constexpr unsigned long long app_id_override = 0x24480451;
+
 #pragma region spoofing hooks for 16xx
 
 // NvAPI_GPU_GetArchInfo hooking based on Nukem's spoofing code here

--- a/OptiScaler/imgui/imgui_common.cpp
+++ b/OptiScaler/imgui/imgui_common.cpp
@@ -1744,6 +1744,20 @@ void ImGuiCommon::RenderMenu()
                                 Config::Instance()->changeBackend = true;
                             }
                         }
+
+                        if (Config::Instance()->AdvancedSettings.value_or(false) && currentBackend == "dlss")
+                        {
+                            bool appIdOverride = Config::Instance()->UseGenericAppIdWithDlss.value_or(false);
+
+                            if (ImGui::Checkbox("Use Generic App Id with DLSS", &appIdOverride))
+                            {
+                                Config::Instance()->UseGenericAppIdWithDlss = appIdOverride;
+                            }
+
+                            ShowHelpMarker("Use generic appid with NGX\n"
+                                "Fixes OptiScaler preset override not working with certain games\n"
+                                "Requires a game restart.");
+                        }
                     }
                 }
 

--- a/nvngx.ini
+++ b/nvngx.ini
@@ -502,6 +502,10 @@ ExposureResourceBarrier=auto
 ; Default (auto) is state correction disabled
 OutputResourceBarrier=auto
 
+; Use generic appid with NGX, fixes OptiScaler preset override not working with certain games
+; true or false - Default (auto) is false
+UseGenericAppIdWithDlss=auto
+
 ; These settings defines each resources initial resource 
 ; state and add resource barrier for correct state
 ;


### PR DESCRIPTION
This fixes preset overriding on games like Monster Hunter Rise, that have fixed presets on ther appId inside DLSS.