### PR TITLE
feat: don't return Ultra Quality to real DLSS

### DIFF
--- a/OptiScaler/backends/dlss/DLSSFeature.cpp
+++ b/OptiScaler/backends/dlss/DLSSFeature.cpp
@@ -309,6 +309,14 @@ void DLSSFeature::ProcessInitParams(NVSDK_NGX_Parameter* InParameters)
     InParameters->Set("RayReconstruction.Hint.Render.Preset.Performance", RenderPresetPerformance);
     InParameters->Set("RayReconstruction.Hint.Render.Preset.UltraPerformance", RenderPresetUltraPerformance);
 
+
+    UINT perfQ = NVSDK_NGX_PerfQuality_Value_Balanced;
+    if (InParameters->Get(NVSDK_NGX_Parameter_PerfQualityValue, &perfQ) == NVSDK_NGX_Result_Success &&
+        perfQ == NVSDK_NGX_PerfQuality_Value_UltraQuality)
+    {
+        InParameters->Set(NVSDK_NGX_Parameter_PerfQualityValue, NVSDK_NGX_PerfQuality_Value_MaxQuality);
+    }
+
     LOG_FUNC_RESULT(0);
 }
 


### PR DESCRIPTION
According to the NVIDIA docs, game devs are expected to check if a given PerfQuality mode is enabled for a DLSS version by calling NVSDK_NGX_DLSS_GetOptimalSettingsCallback and checking if the the OptimalWidth/OptimalHeight > 0.

![image](https://github.com/user-attachments/assets/bf45bc55-c529-4be7-9029-33ed560c2abc)

Satisfactory does that, and if it's present, it will try to use NVSDK_NGX_PerfQuality_Value_UltraQuality as a mode for ANY DLSS mode that isn't DLAA. 

This causes the real DLSS runtime to throw an error on feature creation when used with OptiScaler, and this PR fixes that by returning that Ultra Quality isn't available when the real DLSS is enabled.  
