### PR TITLE
Add fakenvapi settings to the menu

### DIFF
--- a/OptiScaler/Config.cpp
+++ b/OptiScaler/Config.cpp
@@ -384,7 +384,7 @@ bool Config::Reload(std::filesystem::path iniPath)
                 DE_ReflexEmu.reset();
         }
 
-        if (OverrideNvapiDll.has_value() && OverrideNvapiDll.value())
+        if (FN_Available)
             return ReloadFakenvapi();
         
         return true;

--- a/OptiScaler/Config.h
+++ b/OptiScaler/Config.h
@@ -181,6 +181,14 @@ public:
 	std::optional<std::string> DE_Reflex;			// on - boost - off
 	std::optional<std::string> DE_ReflexEmu;		// auto - on - off
 
+	// fakenvapi
+	bool FN_Available = false;
+	std::optional<bool> FN_EnableLogs;
+	std::optional<bool> FN_EnableTraceLogs;
+	std::optional<bool> FN_ForceLatencyFlex;
+	std::optional<uint32_t> FN_LatencyFlexMode;		// conservative - aggressive - reflex ids
+	std::optional<uint32_t> FN_ForceReflex;			// in-game - force disable - force enable
+
 	// for realtime changes
 	bool changeBackend = false;
 	std::string newBackend = "";
@@ -225,12 +233,16 @@ public:
 	bool LoadFromPath(const wchar_t* InPath);
 	bool SaveIni();
 
+	bool ReloadFakenvapi();
+	bool SaveFakenvapiIni();
+
 	static Config* Instance();
 
 private:
 	inline static Config* _config;
 
 	CSimpleIniA ini;
+	CSimpleIniA fakenvapiIni;
 	std::filesystem::path absoluteFileName;
 
 	std::optional<std::string> readString(std::string section, std::string key, bool lowercase = false);

--- a/OptiScaler/imgui/imgui_common.h
+++ b/OptiScaler/imgui/imgui_common.h
@@ -120,6 +120,8 @@ private:
 
     static void AddRenderPreset(std::string name, std::optional<uint32_t>* value);
 
+    static void PopulateCombo(std::string name, std::optional<uint32_t>* value, const char* names[], const char* desc[], int length);
+
 public:
 
     static void Dx11Inited() { _dx11Ready = true; }


### PR DESCRIPTION
Just making fakenvapi.ini file editable in the menu. Fakenvapi starting with version 1.1.1 watches for the config file changes and applies them live. When combined with an older versions of fakenvapi, a game restart is needed.