### PR TITLE
Add support for dlssg-to-fsr3 mod

### DIFF
--- a/OptiScaler/Config.cpp
+++ b/OptiScaler/Config.cpp
@@ -823,11 +823,7 @@ bool Config::SaveIni()
 
     // Frame Generation 
     {
-        if (Instance()->DLSSGMod.value_or(false))
-            ini.SetValue("FrameGen", "UseFGSwapChain", "auto");
-        else
-            ini.SetValue("FrameGen", "UseFGSwapChain", GetBoolValue(Instance()->FGUseFGSwapChain).c_str());
-
+        ini.SetValue("FrameGen", "UseFGSwapChain", GetBoolValue(Instance()->FGUseFGSwapChain).c_str());
         ini.SetValue("FrameGen", "Enabled", GetBoolValue(Instance()->FGEnabled).c_str());
         ini.SetValue("FrameGen", "DebugView", GetBoolValue(Instance()->FGDebugView).c_str());
         ini.SetValue("FrameGen", "AllowAsync", GetBoolValue(Instance()->FGAsync).c_str());

--- a/OptiScaler/Config.h
+++ b/OptiScaler/Config.h
@@ -15,6 +15,12 @@ typedef enum NVNGX_Api
 	NVNGX_VULKAN,
 } NVNGX_Api;
 
+typedef enum GameQuirk 
+{
+	Other,
+	Cyberpunk
+} GameQuirk;
+
 class Config
 {
 public:
@@ -56,6 +62,11 @@ public:
 	std::optional<uint32_t> RenderPresetBalanced;
 	std::optional<uint32_t> RenderPresetPerformance;
 	std::optional<uint32_t> RenderPresetUltraPerformance;
+
+	// DLSSG
+	std::optional<bool> SpoofHAGS;
+	std::optional<bool> DLSSGMod;
+	GameQuirk gameQuirk = Other;
 
 	// CAS
 	std::optional<bool> RcasEnabled;

--- a/OptiScaler/DLSSG_Mod.h
+++ b/OptiScaler/DLSSG_Mod.h
@@ -1,0 +1,294 @@
+#pragma once
+
+#include "NVNGX_Proxy.h"
+
+#define DLSSG_MOD_ID_OFFSET 2000000
+
+class DLSSGMod
+{
+private:
+    inline static HMODULE _dll = nullptr;
+    inline static PFN_D3D12_Init _DLSSG_D3D12_Init = nullptr;
+    inline static PFN_D3D12_Init_Ext _DLSSG_D3D12_Init_Ext = nullptr;
+    inline static PFN_D3D12_Shutdown _DLSSG_D3D12_Shutdown = nullptr;
+    inline static PFN_D3D12_Shutdown1 _DLSSG_D3D12_Shutdown1 = nullptr;
+    inline static PFN_D3D12_GetScratchBufferSize _DLSSG_D3D12_GetScratchBufferSize = nullptr;
+    inline static PFN_D3D12_CreateFeature _DLSSG_D3D12_CreateFeature = nullptr;
+    inline static PFN_D3D12_ReleaseFeature _DLSSG_D3D12_ReleaseFeature = nullptr;
+    inline static PFN_D3D12_GetFeatureRequirements _DLSSG_D3D12_GetFeatureRequirements = nullptr; // unused
+    inline static PFN_D3D12_EvaluateFeature _DLSSG_D3D12_EvaluateFeature = nullptr;
+    inline static PFN_D3D12_PopulateParameters_Impl _DLSSG_D3D12_PopulateParameters_Impl = nullptr;
+
+    inline static PFN_VULKAN_Init _DLSSG_VULKAN_Init = nullptr;
+    inline static PFN_VULKAN_Init_Ext _DLSSG_VULKAN_Init_Ext = nullptr;
+    inline static PFN_VULKAN_Init_Ext2 _DLSSG_VULKAN_Init_Ext2 = nullptr;
+    inline static PFN_VULKAN_Shutdown _DLSSG_VULKAN_Shutdown = nullptr;
+    inline static PFN_VULKAN_Shutdown1 _DLSSG_VULKAN_Shutdown1 = nullptr;
+    inline static PFN_VULKAN_GetScratchBufferSize _DLSSG_VULKAN_GetScratchBufferSize = nullptr;
+    inline static PFN_VULKAN_CreateFeature _DLSSG_VULKAN_CreateFeature = nullptr;
+    inline static PFN_VULKAN_CreateFeature1 _DLSSG_VULKAN_CreateFeature1 = nullptr;
+    inline static PFN_VULKAN_ReleaseFeature _DLSSG_VULKAN_ReleaseFeature = nullptr;
+    inline static PFN_VULKAN_GetFeatureRequirements _DLSSG_VULKAN_GetFeatureRequirements = nullptr; // unused
+    inline static PFN_VULKAN_EvaluateFeature _DLSSG_VULKAN_EvaluateFeature = nullptr;
+    inline static PFN_VULKAN_PopulateParameters_Impl _DLSSG_VULKAN_PopulateParameters_Impl = nullptr;
+
+    inline static bool dx12_inited = false;
+    inline static bool vulkan_inited = false;
+public:
+    static void InitDLSSGMod_Dx12() {
+        LOG_FUNC();
+
+        if (dx12_inited)
+            return;
+
+        if (Config::Instance()->DLSSGMod.value_or(false) && !Config::Instance()->DE_Available) {
+            if (_dll == nullptr)
+                _dll = LoadLibraryW(L"dlssg_to_fsr3_amd_is_better.dll");
+
+            if (_dll != nullptr) {
+                _DLSSG_D3D12_Init = (PFN_D3D12_Init)GetProcAddress(_dll, "NVSDK_NGX_D3D12_Init");
+                _DLSSG_D3D12_Init_Ext = (PFN_D3D12_Init_Ext)GetProcAddress(_dll, "NVSDK_NGX_D3D12_Init_Ext");
+                _DLSSG_D3D12_Shutdown = (PFN_D3D12_Shutdown)GetProcAddress(_dll, "NVSDK_NGX_D3D12_Shutdown");
+                _DLSSG_D3D12_Shutdown1 = (PFN_D3D12_Shutdown1)GetProcAddress(_dll, "NVSDK_NGX_D3D12_Shutdown1");
+                _DLSSG_D3D12_GetScratchBufferSize = (PFN_D3D12_GetScratchBufferSize)GetProcAddress(_dll, "NVSDK_NGX_D3D12_GetScratchBufferSize");
+                _DLSSG_D3D12_CreateFeature = (PFN_D3D12_CreateFeature)GetProcAddress(_dll, "NVSDK_NGX_D3D12_CreateFeature");
+                _DLSSG_D3D12_ReleaseFeature = (PFN_D3D12_ReleaseFeature)GetProcAddress(_dll, "NVSDK_NGX_D3D12_ReleaseFeature");
+                _DLSSG_D3D12_GetFeatureRequirements = (PFN_D3D12_GetFeatureRequirements)GetProcAddress(_dll, "NVSDK_NGX_D3D12_GetFeatureRequirements");
+                _DLSSG_D3D12_EvaluateFeature = (PFN_D3D12_EvaluateFeature)GetProcAddress(_dll, "NVSDK_NGX_D3D12_EvaluateFeature");
+                _DLSSG_D3D12_PopulateParameters_Impl = (PFN_D3D12_PopulateParameters_Impl)GetProcAddress(_dll, "NVSDK_NGX_D3D12_PopulateParameters_Impl");
+                dx12_inited = true;
+
+                LOG_INFO("DLSSG Mod initialized for DX12");
+            }
+            else {
+                LOG_INFO("DLSSG Mod enabled but cannot be loaded");
+            }
+        }
+    }
+
+    static void InitDLSSGMod_Vulkan() {
+        LOG_FUNC();
+
+        if (vulkan_inited)
+            return;
+
+        if (Config::Instance()->DLSSGMod.value_or(false) && !Config::Instance()->DE_Available) {
+            if (_dll == nullptr)
+                _dll = LoadLibraryW(L"dlssg_to_fsr3_amd_is_better.dll");
+
+            if (_dll != nullptr) {
+                _DLSSG_VULKAN_Init = (PFN_VULKAN_Init)GetProcAddress(_dll, "NVSDK_NGX_VULKAN_Init");
+                _DLSSG_VULKAN_Init_Ext = (PFN_VULKAN_Init_Ext)GetProcAddress(_dll, "NVSDK_NGX_VULKAN_Init_Ext");
+                _DLSSG_VULKAN_Init_Ext2 = (PFN_VULKAN_Init_Ext2)GetProcAddress(_dll, "NVSDK_NGX_VULKAN_Init_Ext2");
+                _DLSSG_VULKAN_Shutdown = (PFN_VULKAN_Shutdown)GetProcAddress(_dll, "NVSDK_NGX_VULKAN_Shutdown");
+                _DLSSG_VULKAN_Shutdown1 = (PFN_VULKAN_Shutdown1)GetProcAddress(_dll, "NVSDK_NGX_VULKAN_Shutdown1");
+                _DLSSG_VULKAN_GetScratchBufferSize = (PFN_VULKAN_GetScratchBufferSize)GetProcAddress(_dll, "NVSDK_NGX_VULKAN_GetScratchBufferSize");
+                _DLSSG_VULKAN_CreateFeature = (PFN_VULKAN_CreateFeature)GetProcAddress(_dll, "NVSDK_NGX_VULKAN_CreateFeature");
+                _DLSSG_VULKAN_CreateFeature1 = (PFN_VULKAN_CreateFeature1)GetProcAddress(_dll, "NVSDK_NGX_VULKAN_CreateFeature1");
+                _DLSSG_VULKAN_ReleaseFeature = (PFN_VULKAN_ReleaseFeature)GetProcAddress(_dll, "NVSDK_NGX_VULKAN_ReleaseFeature");
+                _DLSSG_VULKAN_GetFeatureRequirements = (PFN_VULKAN_GetFeatureRequirements)GetProcAddress(_dll, "NVSDK_NGX_VULKAN_GetFeatureRequirements");
+                _DLSSG_VULKAN_EvaluateFeature = (PFN_VULKAN_EvaluateFeature)GetProcAddress(_dll, "NVSDK_NGX_VULKAN_EvaluateFeature");
+                _DLSSG_VULKAN_PopulateParameters_Impl = (PFN_VULKAN_PopulateParameters_Impl)GetProcAddress(_dll, "NVSDK_NGX_VULKAN_PopulateParameters_Impl");
+                vulkan_inited = true;
+
+                LOG_INFO("DLSSG Mod initialized for Vulkan");
+            }
+            else {
+                LOG_INFO("DLSSG Mod enabled but cannot be loaded");
+            }
+        }
+    }
+
+    static inline bool isLoaded() {
+        return _dll != nullptr;
+    }
+
+    static inline bool isDx12Available() {
+        return isLoaded() && dx12_inited;
+    }
+
+    static inline NVSDK_NGX_Result D3D12_Init(unsigned long long InApplicationId, const wchar_t* InApplicationDataPath, ID3D12Device* InDevice, const NVSDK_NGX_FeatureCommonInfo* InFeatureInfo, NVSDK_NGX_Version InSDKVersion)
+    {
+        if (isDx12Available())
+            return _DLSSG_D3D12_Init(InApplicationId, InApplicationDataPath, InDevice, InFeatureInfo, InSDKVersion);
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    static inline NVSDK_NGX_Result D3D12_Init_Ext(unsigned long long InApplicationId, const wchar_t* InApplicationDataPath, ID3D12Device* InDevice, NVSDK_NGX_Version InSDKVersion, const NVSDK_NGX_FeatureCommonInfo* InFeatureInfo)
+    {
+        if (isDx12Available())
+            return _DLSSG_D3D12_Init_Ext(InApplicationId, InApplicationDataPath, InDevice, InSDKVersion, InFeatureInfo);
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    static inline NVSDK_NGX_Result D3D12_Shutdown()
+    {
+        if (isDx12Available())
+            return _DLSSG_D3D12_Shutdown();
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    static inline NVSDK_NGX_Result D3D12_Shutdown1(ID3D12Device* InDevice)
+    {
+        if (isDx12Available())
+            return _DLSSG_D3D12_Shutdown1(InDevice);
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    static inline NVSDK_NGX_Result D3D12_GetScratchBufferSize(NVSDK_NGX_Feature InFeatureId, const NVSDK_NGX_Parameter* InParameters, size_t* OutSizeInBytes)
+    {
+        if (isDx12Available())
+            return _DLSSG_D3D12_GetScratchBufferSize(InFeatureId, InParameters, OutSizeInBytes);
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    static inline NVSDK_NGX_Result D3D12_CreateFeature(ID3D12GraphicsCommandList* InCmdList, NVSDK_NGX_Feature InFeatureID, NVSDK_NGX_Parameter* InParameters, NVSDK_NGX_Handle** OutHandle)
+    {
+        if (isDx12Available()) {
+            auto result = _DLSSG_D3D12_CreateFeature(InCmdList, InFeatureID, InParameters, OutHandle);
+            (*OutHandle)->Id += DLSSG_MOD_ID_OFFSET;
+            return result;
+        }
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    static inline NVSDK_NGX_Result D3D12_ReleaseFeature(NVSDK_NGX_Handle* InHandle)
+    {
+        if (isDx12Available() && InHandle->Id >= DLSSG_MOD_ID_OFFSET) {
+            NVSDK_NGX_Handle TempHandle = {
+                .Id = InHandle->Id - DLSSG_MOD_ID_OFFSET
+            };
+            return _DLSSG_D3D12_ReleaseFeature(&TempHandle);
+        }
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    static inline NVSDK_NGX_Result D3D12_GetFeatureRequirements(IDXGIAdapter* Adapter, const NVSDK_NGX_FeatureDiscoveryInfo* FeatureDiscoveryInfo, NVSDK_NGX_FeatureRequirement* OutSupported)
+    {
+        if (isDx12Available())
+            return _DLSSG_D3D12_GetFeatureRequirements(Adapter, FeatureDiscoveryInfo, OutSupported);
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    static inline NVSDK_NGX_Result D3D12_EvaluateFeature(ID3D12GraphicsCommandList* InCmdList, const NVSDK_NGX_Handle* InFeatureHandle, const NVSDK_NGX_Parameter* InParameters, PFN_NVSDK_NGX_ProgressCallback InCallback)
+    {
+        if (isDx12Available() && InFeatureHandle->Id >= DLSSG_MOD_ID_OFFSET) {
+            NVSDK_NGX_Handle TempHandle = {
+                .Id = InFeatureHandle->Id - DLSSG_MOD_ID_OFFSET
+            };
+            return _DLSSG_D3D12_EvaluateFeature(InCmdList, &TempHandle, InParameters, InCallback);
+        }
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    static inline NVSDK_NGX_Result D3D12_PopulateParameters_Impl(NVSDK_NGX_Parameter* InParameters)
+    {
+        if (isDx12Available())
+            return _DLSSG_D3D12_PopulateParameters_Impl(InParameters);
+        return NVSDK_NGX_Result_Fail;
+    }
+
+
+
+    static inline bool isVulkanAvailable() {
+        return isLoaded() && vulkan_inited;
+    }
+
+    static inline NVSDK_NGX_Result VULKAN_Init(unsigned long long InApplicationId, const wchar_t* InApplicationDataPath, VkInstance InInstance, VkPhysicalDevice InPD, VkDevice InDevice, PFN_vkGetInstanceProcAddr InGIPA, PFN_vkGetDeviceProcAddr InGDPA, const NVSDK_NGX_FeatureCommonInfo* InFeatureInfo, NVSDK_NGX_Version InSDKVersion)
+    {
+        if (isVulkanAvailable())
+            return _DLSSG_VULKAN_Init(InApplicationId, InApplicationDataPath, InInstance, InPD, InDevice, InGIPA, InGDPA, InFeatureInfo, InSDKVersion);
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    static inline NVSDK_NGX_Result VULKAN_Init_Ext(unsigned long long InApplicationId, const wchar_t* InApplicationDataPath, VkInstance InInstance, VkPhysicalDevice InPD, VkDevice InDevice, NVSDK_NGX_Version InSDKVersion, const NVSDK_NGX_FeatureCommonInfo* InFeatureInfo)
+    {
+        if (isVulkanAvailable())
+            return _DLSSG_VULKAN_Init_Ext(InApplicationId, InApplicationDataPath, InInstance, InPD, InDevice, InSDKVersion, InFeatureInfo);
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    static inline NVSDK_NGX_Result VULKAN_Init_Ext2(unsigned long long InApplicationId, const wchar_t* InApplicationDataPath, VkInstance InInstance, VkPhysicalDevice InPD, VkDevice InDevice, PFN_vkGetInstanceProcAddr InGIPA, PFN_vkGetDeviceProcAddr InGDPA, NVSDK_NGX_Version InSDKVersion, const NVSDK_NGX_FeatureCommonInfo* InFeatureInfo)
+    {
+        if (isVulkanAvailable())
+            return _DLSSG_VULKAN_Init_Ext2(InApplicationId, InApplicationDataPath, InInstance, InPD, InDevice, InGIPA, InGDPA, InSDKVersion, InFeatureInfo);
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    static inline NVSDK_NGX_Result VULKAN_Shutdown()
+    {
+        if (isVulkanAvailable())
+            return _DLSSG_VULKAN_Shutdown();
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    static inline NVSDK_NGX_Result VULKAN_Shutdown1(VkDevice InDevice)
+    {
+        if (isVulkanAvailable())
+            return _DLSSG_VULKAN_Shutdown1(InDevice);
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    static inline NVSDK_NGX_Result VULKAN_GetScratchBufferSize(NVSDK_NGX_Feature InFeatureId, const NVSDK_NGX_Parameter* InParameters, size_t* OutSizeInBytes)
+    {
+        if (isVulkanAvailable())
+            return _DLSSG_VULKAN_GetScratchBufferSize(InFeatureId, InParameters, OutSizeInBytes);
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    static inline NVSDK_NGX_Result VULKAN_CreateFeature(VkCommandBuffer InCmdBuffer, NVSDK_NGX_Feature InFeatureID, NVSDK_NGX_Parameter* InParameters, NVSDK_NGX_Handle** OutHandle)
+    {
+        if (isVulkanAvailable()) {
+            auto result = _DLSSG_VULKAN_CreateFeature(InCmdBuffer, InFeatureID, InParameters, OutHandle);
+            (*OutHandle)->Id += DLSSG_MOD_ID_OFFSET;
+            return result;
+        }
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    static inline NVSDK_NGX_Result VULKAN_CreateFeature1(VkDevice InDevice, VkCommandBuffer InCmdList, NVSDK_NGX_Feature InFeatureID, NVSDK_NGX_Parameter* InParameters, NVSDK_NGX_Handle** OutHandle)
+    {
+        if (isVulkanAvailable()) {
+            auto result = _DLSSG_VULKAN_CreateFeature1(InDevice, InCmdList, InFeatureID, InParameters, OutHandle);
+            (*OutHandle)->Id += DLSSG_MOD_ID_OFFSET;
+            return result;
+        }
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    static inline NVSDK_NGX_Result VULKAN_ReleaseFeature(NVSDK_NGX_Handle* InHandle)
+    {
+        if (isVulkanAvailable() && InHandle->Id >= DLSSG_MOD_ID_OFFSET) {
+            NVSDK_NGX_Handle TempHandle = {
+                .Id = InHandle->Id - DLSSG_MOD_ID_OFFSET
+            };
+            return _DLSSG_VULKAN_ReleaseFeature(&TempHandle);
+        }
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    static inline NVSDK_NGX_Result VULKAN_GetFeatureRequirements(const VkInstance Instance, const VkPhysicalDevice PhysicalDevice, const NVSDK_NGX_FeatureDiscoveryInfo* FeatureDiscoveryInfo, NVSDK_NGX_FeatureRequirement* OutSupported)
+    {
+        if (isVulkanAvailable())
+            return _DLSSG_VULKAN_GetFeatureRequirements(Instance, PhysicalDevice, FeatureDiscoveryInfo, OutSupported);
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    static inline NVSDK_NGX_Result VULKAN_EvaluateFeature(VkCommandBuffer InCmdList, const NVSDK_NGX_Handle* InFeatureHandle, const NVSDK_NGX_Parameter* InParameters, PFN_NVSDK_NGX_ProgressCallback InCallback)
+    {
+        if (isVulkanAvailable() && InFeatureHandle->Id >= DLSSG_MOD_ID_OFFSET) {
+            NVSDK_NGX_Handle TempHandle = {
+                .Id = InFeatureHandle->Id - DLSSG_MOD_ID_OFFSET
+            };
+            return _DLSSG_VULKAN_EvaluateFeature(InCmdList, &TempHandle, InParameters, InCallback);
+        }
+        return NVSDK_NGX_Result_Fail;
+    }
+
+    static inline NVSDK_NGX_Result VULKAN_PopulateParameters_Impl(NVSDK_NGX_Parameter* InParameters)
+    {
+        if (isVulkanAvailable())
+            return _DLSSG_VULKAN_PopulateParameters_Impl(InParameters);
+        return NVSDK_NGX_Result_Fail;
+    }
+};

--- a/OptiScaler/Gdi32_Proxy.h
+++ b/OptiScaler/Gdi32_Proxy.h
@@ -1,0 +1,160 @@
+#pragma once
+
+#include "pch.h"
+
+#include "Config.h"
+
+#include "detours/detours.h"
+
+typedef struct _D3DKMT_WDDM_2_7_CAPS
+{
+    union
+    {
+        struct
+        {
+            UINT HwSchSupported : 1;
+            UINT HwSchEnabled : 1;
+            UINT HwSchEnabledByDefault : 1;
+            UINT IndependentVidPnVSyncControl : 1;
+            UINT Reserved : 28;
+        };
+        UINT Value;
+    };
+} D3DKMT_WDDM_2_7_CAPS;
+
+typedef enum _KMTQUERYADAPTERINFOTYPE
+{
+    KMTQAITYPE_WDDM_2_7_CAPS = 70,
+} KMTQUERYADAPTERINFOTYPE;
+
+typedef struct _D3DKMT_QUERYADAPTERINFO
+{
+    UINT hAdapter;
+    KMTQUERYADAPTERINFOTYPE Type;
+    VOID* pPrivateDriverData;
+    UINT PrivateDriverDataSize;
+} D3DKMT_QUERYADAPTERINFO;
+
+using D3DKMT_HANDLE = uint64_t;
+
+typedef struct _D3DKMT_ADAPTERINFO {
+    D3DKMT_HANDLE hAdapter;
+    LUID AdapterLuid;
+    ULONG NumOfSources;
+    BOOL bPrecisePresentRegionsPreferred;
+} D3DKMT_ADAPTERINFO;
+
+typedef struct _D3DKMT_ENUMADAPTERS2 {
+    ULONG NumAdapters;
+    D3DKMT_ADAPTERINFO* pAdapters;
+} D3DKMT_ENUMADAPTERS2;
+
+typedef int(*PFN_D3DKMTQueryAdapterInfo)(const D3DKMT_QUERYADAPTERINFO* data);
+
+static PFN_D3DKMTQueryAdapterInfo o_D3DKMTQueryAdapterInfo = nullptr;
+
+static int hkD3DKMTQueryAdapterInfo(const D3DKMT_QUERYADAPTERINFO* data) {
+    //LOG_INFO("Adapter into type: {}", (uint32_t)data->Type);
+    if (data->Type == KMTQAITYPE_WDDM_2_7_CAPS) {
+        LOG_INFO("Spoofing HAGS");
+
+        if (data->pPrivateDriverData == nullptr) {
+            LOG_ERROR("HAGS data nullptr");
+            return 0xFFFFFFFF;
+        }
+
+        auto d3dkmt_wddm_2_7_caps = static_cast<D3DKMT_WDDM_2_7_CAPS*>(data->pPrivateDriverData);
+        d3dkmt_wddm_2_7_caps->HwSchSupported = 1;
+        d3dkmt_wddm_2_7_caps->HwSchEnabled = 1;
+        d3dkmt_wddm_2_7_caps->HwSchEnabledByDefault = 0;
+        d3dkmt_wddm_2_7_caps->IndependentVidPnVSyncControl = 0;
+
+        return 0;
+    }
+    else
+    {
+        return o_D3DKMTQueryAdapterInfo(data);
+    }
+}
+
+// Only for Linux, Wine doesn't have this function
+static int customD3DKMTEnumAdapters2(const D3DKMT_ENUMADAPTERS2* data) {
+    LOG_FUNC();
+
+    // Try to detect streamline
+    if (data->pAdapters != nullptr && data->NumAdapters == 8) {
+        LOG_INFO("Streamline detected");
+
+        static D3DKMT_ADAPTERINFO* adapters = []() -> D3DKMT_ADAPTERINFO* {
+            D3DKMT_ADAPTERINFO pAdapters[8]{};
+            HRESULT hr = S_OK;
+
+            IDXGIFactory* pFactory = nullptr;
+            hr = CreateDXGIFactory(__uuidof(IDXGIFactory), (void**)&pFactory);
+            if (FAILED(hr)) {
+                LOG_DEBUG("Couldn't create a dxgi factory");
+                return pAdapters;
+            }
+
+            IDXGIAdapter* pAdapter = nullptr;
+            for (UINT i = 0; pFactory->EnumAdapters(i, &pAdapter) != DXGI_ERROR_NOT_FOUND; ++i) {
+                DXGI_ADAPTER_DESC desc;
+                pAdapter->GetDesc(&desc);
+                
+                pAdapters[i].AdapterLuid.HighPart = desc.AdapterLuid.HighPart;
+                pAdapters[i].AdapterLuid.LowPart = desc.AdapterLuid.LowPart;
+                
+                pAdapter->Release();
+            }
+
+            pFactory->Release();
+
+            return pAdapters;
+        }();
+
+        // Something's not quite right in here
+        // Can't just send all LUIDs from DXGI as streamline isn't happy
+        // Can't send a true number of adapters as streamline isn't happy
+        // 8th adapter sometimes has junk data so sending only 6 to be safe
+
+        for (uint32_t i = 0; i < 6; i++) {
+            data->pAdapters[i].AdapterLuid.HighPart = adapters[0].AdapterLuid.HighPart;
+            data->pAdapters[i].AdapterLuid.LowPart  = adapters[0].AdapterLuid.LowPart;
+            LOG_DEBUG("sent {}.{}", data->pAdapters[i].AdapterLuid.HighPart, data->pAdapters[i].AdapterLuid.LowPart);
+        }
+
+        return 0;
+    }
+
+    return 0xFFFFFFFF;
+}
+
+// for spoofing HAGS, call early
+static void hookGdi32() {
+    LOG_FUNC();
+
+    if (Config::Instance()->SpoofHAGS.value_or(false) || Config::Instance()->DLSSGMod.value_or(false)) {
+        o_D3DKMTQueryAdapterInfo = reinterpret_cast<PFN_D3DKMTQueryAdapterInfo>(DetourFindFunction("gdi32.dll", "D3DKMTQueryAdapterInfo"));
+
+        if (o_D3DKMTQueryAdapterInfo != nullptr) {
+            DetourTransactionBegin();
+            DetourUpdateThread(GetCurrentThread());
+
+            DetourAttach(&(PVOID&)o_D3DKMTQueryAdapterInfo, hkD3DKMTQueryAdapterInfo);
+
+            DetourTransactionCommit();
+        }
+    }
+}
+
+static void unhookGdi32() {
+    if (o_D3DKMTQueryAdapterInfo != nullptr) {
+        DetourTransactionBegin();
+        DetourUpdateThread(GetCurrentThread());
+
+        DetourDetach(&(PVOID&)o_D3DKMTQueryAdapterInfo, hkD3DKMTQueryAdapterInfo);
+        o_D3DKMTQueryAdapterInfo = nullptr;
+
+        DetourTransactionCommit();
+    }
+}

--- a/OptiScaler/NVNGX_Parameter.h
+++ b/OptiScaler/NVNGX_Parameter.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "pch.h"
 #include "Config.h"
+#include "DLSSG_Mod.h"
 
 #include <ankerl/unordered_dense.h>
 
@@ -456,6 +457,15 @@ inline static void InitNGXParameters(NVSDK_NGX_Parameter* InParams)
     InParams->Set(NVSDK_NGX_Parameter_VisibilityNodeMask, 1);
     InParams->Set(NVSDK_NGX_Parameter_DLSS_Enable_Output_Subrects, 1);
     InParams->Set(NVSDK_NGX_Parameter_RTXValue, 0);
+
+    // not ideal as it doesn't take different APIs into account
+    if (DLSSGMod::isLoaded()) {
+        InParams->Set("FrameGeneration.Available", 1);
+        InParams->Set("FrameInterpolation.Available", 1);
+        InParams->Set(NVSDK_NGX_Parameter_FrameInterpolation_NeedsUpdatedDriver, 0);
+        InParams->Set(NVSDK_NGX_Parameter_FrameInterpolation_FeatureInitResult, 1);
+        InParams->Set(NVSDK_NGX_Parameter_FrameInterpolation_MinDriverVersionMajor, 0);
+    }
 }
 
 struct Parameter

--- a/OptiScaler/NVNGX_Proxy.h
+++ b/OptiScaler/NVNGX_Proxy.h
@@ -182,6 +182,7 @@ typedef NVSDK_NGX_Result(*PFN_D3D12_CreateFeature)(ID3D12GraphicsCommandList* In
 typedef NVSDK_NGX_Result(*PFN_D3D12_ReleaseFeature)(NVSDK_NGX_Handle* InHandle);
 typedef NVSDK_NGX_Result(*PFN_D3D12_GetFeatureRequirements)(IDXGIAdapter* Adapter, const NVSDK_NGX_FeatureDiscoveryInfo* FeatureDiscoveryInfo, NVSDK_NGX_FeatureRequirement* OutSupported);
 typedef NVSDK_NGX_Result(*PFN_D3D12_EvaluateFeature)(ID3D12GraphicsCommandList* InCmdList, const NVSDK_NGX_Handle* InFeatureHandle, const NVSDK_NGX_Parameter* InParameters, PFN_NVSDK_NGX_ProgressCallback InCallback);
+typedef NVSDK_NGX_Result(*PFN_D3D12_PopulateParameters_Impl)(NVSDK_NGX_Parameter* InParameters);
 
 typedef NVSDK_NGX_Result(*PFN_UpdateFeature)(const NVSDK_NGX_Application_Identifier* ApplicationId, const NVSDK_NGX_Feature FeatureID);
 
@@ -205,6 +206,7 @@ typedef NVSDK_NGX_Result(*PFN_VULKAN_GetFeatureRequirements)(const VkInstance In
 typedef NVSDK_NGX_Result(*PFN_VULKAN_GetFeatureInstanceExtensionRequirements)(const NVSDK_NGX_FeatureDiscoveryInfo* FeatureDiscoveryInfo, uint32_t* OutExtensionCount, VkExtensionProperties** OutExtensionProperties);
 typedef NVSDK_NGX_Result(*PFN_VULKAN_GetFeatureDeviceExtensionRequirements)(VkInstance Instance, VkPhysicalDevice PhysicalDevice, const NVSDK_NGX_FeatureDiscoveryInfo* FeatureDiscoveryInfo, uint32_t* OutExtensionCount, VkExtensionProperties** OutExtensionProperties);
 typedef NVSDK_NGX_Result(*PFN_VULKAN_EvaluateFeature)(VkCommandBuffer InCmdList, const NVSDK_NGX_Handle* InFeatureHandle, const NVSDK_NGX_Parameter* InParameters, PFN_NVSDK_NGX_ProgressCallback InCallback);
+typedef NVSDK_NGX_Result(*PFN_VULKAN_PopulateParameters_Impl)(NVSDK_NGX_Parameter* InParameters);
 
 class NVNGXProxy
 {

--- a/OptiScaler/OptiScaler.vcxproj
+++ b/OptiScaler/OptiScaler.vcxproj
@@ -215,6 +215,8 @@ copy NUL "$(SolutionDir)x64\Release\a\!! EXTRACT ALL FILES TO GAME FOLDER !!"</C
     <ClInclude Include="bias\Bias_Dx12.h" />
     <ClInclude Include="bias\Bias_Dx11.h" />
     <ClInclude Include="bias\precompile\Bias_Shader.h" />
+    <ClInclude Include="DLSSG_Mod.h" />
+    <ClInclude Include="Gdi32_Proxy.h" />
     <ClInclude Include="FfxApi_Dx12.h" />
     <ClInclude Include="FSR2_Dx12.h" />
     <ClInclude Include="FSR3_Dx12.h" />
@@ -282,6 +284,7 @@ copy NUL "$(SolutionDir)x64\Release\a\!! EXTRACT ALL FILES TO GAME FOLDER !!"</C
     <ClInclude Include="rcas\RCAS_Dx12.h" />
     <ClInclude Include="nvapi\ReflexHooks.h" />
     <ClInclude Include="resource.h" />
+    <ClInclude Include="Streamline_Proxy.h" />
     <ClInclude Include="Util.h" />
     <ClInclude Include="backends\xess\XeSSFeature_Dx11.h" />
     <ClInclude Include="XeSS_Proxy.h" />

--- a/OptiScaler/OptiScaler.vcxproj.filters
+++ b/OptiScaler/OptiScaler.vcxproj.filters
@@ -281,6 +281,15 @@
     <ClInclude Include="nvapi\NvApiTypes.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="DLSSG_Mod.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Gdi32_Proxy.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Streamline_Proxy.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="output_scaling\precompile\BCDS_Shader.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/OptiScaler/Streamline_Proxy.h
+++ b/OptiScaler/Streamline_Proxy.h
@@ -1,0 +1,135 @@
+#pragma once
+
+#include "pch.h"
+
+#include <d3d12.h>
+#include "Config.h"
+#include "Util.h"
+
+#include "detours/detours.h"
+#include "../external/streamline/sl.h"
+
+
+typedef int(*PFN_slSetTag)(uint64_t viewport, sl::ResourceTag* tags, uint32_t numTags, uint64_t cmdBuffer);
+typedef int(*PFN_slInit)(sl::Preferences* pref, uint64_t sdkVersion);
+typedef void(*PFN_LogCallback)(sl::LogType type, const char* msg);
+
+static PFN_slSetTag o_slSetTag = nullptr;
+static PFN_slInit o_slInit = nullptr;
+
+static PFN_LogCallback o_logCallback = nullptr;
+
+static char* trimStreamlineLog(const char* msg) {
+    int bracket_count = 0;
+
+    char* result = (char*)malloc(strlen(msg) + 1);
+    if (!result) return NULL;
+
+    strcpy(result, msg);
+
+    size_t length = strlen(result);
+    if (length > 0 && result[length - 1] == '\n') {
+        result[length - 1] = '\0';
+    }
+
+    return result;
+}
+
+static void streamlineLogCallback(sl::LogType type, const char* msg) {
+    char* trimmed_msg = trimStreamlineLog(msg);
+
+    switch (type) {
+    case sl::LogType::eWarn:
+        LOG_WARN("{}", trimmed_msg);
+        break;
+    case sl::LogType::eInfo:
+        LOG_INFO("{}", trimmed_msg);
+        break;
+    case sl::LogType::eError:
+        LOG_ERROR("{}", trimmed_msg);
+        break;
+    case sl::LogType::eCount:
+        LOG_ERROR("{}", trimmed_msg);
+        break;
+    }
+
+    free(trimmed_msg);
+
+    if (o_logCallback != nullptr)
+        o_logCallback(type, msg);
+}
+
+static int hkslInit(sl::Preferences* pref, uint64_t sdkVersion) {
+    LOG_FUNC();
+    // o_logCallback = pref->logMessageCallback; // cyberpunk might be getting itself here
+    pref->logLevel = sl::LogLevel::eCount;
+    pref->logMessageCallback = &streamlineLogCallback;
+    return o_slInit(pref, sdkVersion);
+}
+
+static int hkslSetTag(uint64_t viewport, sl::ResourceTag* tags, uint32_t numTags, uint64_t cmdBuffer) {
+    LOG_FUNC();
+    for (auto i = 0; i < numTags; i++) {
+        if (Config::Instance()->gameQuirk == Cyberpunk && tags[i].type == 2 && tags[i].resource->state == (D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE)) {
+            tags[i].resource->state = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
+            LOG_TRACE("Changing hudless resource state");
+        }
+    }
+    auto result = o_slSetTag(viewport, tags, numTags, cmdBuffer);
+    return result;
+}
+
+static void unhookStreamline() {
+    DetourTransactionBegin();
+    DetourUpdateThread(GetCurrentThread());
+
+    if (o_slSetTag != nullptr) {
+        DetourDetach(&(PVOID&)o_slSetTag, hkslSetTag);
+        o_slSetTag = nullptr;
+    }
+
+    if (o_slInit != nullptr) {
+        DetourDetach(&(PVOID&)o_slInit, hkslInit);
+        o_slInit = nullptr;
+    }
+
+    DetourTransactionCommit();
+}
+
+// Call it just after sl.interposer's load or if sl.interposer is already loaded
+static void hookStreamline(HMODULE slInterposer) {
+    LOG_FUNC();
+
+    if (o_slSetTag != nullptr || o_slInit != nullptr)
+        unhookStreamline();
+
+    if (Config::Instance()->DLSSGMod.value_or(false)) {
+        o_slSetTag = reinterpret_cast<PFN_slSetTag>(GetProcAddress(slInterposer, "slSetTag"));
+        o_slInit = reinterpret_cast<PFN_slInit>(GetProcAddress(slInterposer, "slInit"));
+
+
+        if (o_slSetTag != nullptr && o_slInit != nullptr) {
+            DetourTransactionBegin();
+            DetourUpdateThread(GetCurrentThread());
+
+            // Get a handle for sl.interposer and then the path
+            HMODULE hModule = nullptr;
+            char dllPath[MAX_PATH];
+            GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, reinterpret_cast<LPCSTR>(o_slSetTag), &hModule);
+            GetModuleFileNameA(hModule, dllPath, MAX_PATH);
+
+            Util::version_t sl_version;
+            Util::GetDLLVersion(string_to_wstring(dllPath), &sl_version);
+            LOG_INFO("Streamline version: {}.{}.{}", sl_version.major, sl_version.minor, sl_version.patch);
+
+            if (sl_version.major >= 2) {
+                DetourAttach(&(PVOID&)o_slSetTag, hkslSetTag);
+                // TODO: fix some weird logging loop in cyberpunk
+                DetourAttach(&(PVOID&)o_slInit, hkslInit);
+            }
+
+            DetourTransactionCommit();
+        }
+    }
+}
+

--- a/OptiScaler/Streamline_Proxy.h
+++ b/OptiScaler/Streamline_Proxy.h
@@ -61,14 +61,13 @@ static void streamlineLogCallback(sl::LogType type, const char* msg) {
 
 static int hkslInit(sl::Preferences* pref, uint64_t sdkVersion) {
     LOG_FUNC();
-    // o_logCallback = pref->logMessageCallback; // cyberpunk might be getting itself here
+    // o_logCallback = pref->logMessageCallback; // causes a loop in cyberpunk on linux
     pref->logLevel = sl::LogLevel::eCount;
     pref->logMessageCallback = &streamlineLogCallback;
     return o_slInit(pref, sdkVersion);
 }
 
 static int hkslSetTag(uint64_t viewport, sl::ResourceTag* tags, uint32_t numTags, uint64_t cmdBuffer) {
-    LOG_FUNC();
     for (auto i = 0; i < numTags; i++) {
         if (Config::Instance()->gameQuirk == Cyberpunk && tags[i].type == 2 && tags[i].resource->state == (D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE | D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE)) {
             tags[i].resource->state = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
@@ -124,7 +123,6 @@ static void hookStreamline(HMODULE slInterposer) {
 
             if (sl_version.major >= 2) {
                 DetourAttach(&(PVOID&)o_slSetTag, hkslSetTag);
-                // TODO: fix some weird logging loop in cyberpunk
                 DetourAttach(&(PVOID&)o_slInit, hkslInit);
             }
 

--- a/OptiScaler/Util.h
+++ b/OptiScaler/Util.h
@@ -1,8 +1,17 @@
 #pragma once
 #include <filesystem>
+#include <xess.h>
 
 namespace Util
 {
+	typedef struct _version_t
+	{
+		uint16_t major;
+		uint16_t minor;
+		uint16_t patch;
+		uint16_t reserved;
+	} version_t;
+
 	std::filesystem::path ExePath();
 	std::filesystem::path DllPath();
 	std::optional<std::filesystem::path> NvngxPath();
@@ -10,6 +19,8 @@ namespace Util
 
 
 	HWND GetProcessWindow();
+	bool GetDLLVersion(std::wstring dllPath, version_t* versionOut);
+	bool GetDLLVersion(std::wstring dllPath, xess_version_t* versionOut);
 };
 
 inline void ThrowIfFailed(HRESULT hr)

--- a/OptiScaler/XeSS_Proxy.h
+++ b/OptiScaler/XeSS_Proxy.h
@@ -75,76 +75,6 @@ private:
 
     inline static PFN_xessSetContextParameterF _xessSetContextParameterF = nullptr;
 
-    inline static std::string LogLastError() 
-    {
-        DWORD errorCode = GetLastError();
-        LPWSTR errorBuffer = nullptr;
-        FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-                      NULL, errorCode, 0, (LPWSTR)&errorBuffer, 0, NULL);
-
-        std::string result;
-
-        if (errorBuffer)
-        {
-            std::wstring errMsg(errorBuffer);
-            result = std::format("{} ({})", errorCode, wstring_to_string(errMsg).erase(wstring_to_string(errMsg).find_last_not_of("\t\n\v\f\r ") + 1));
-            LocalFree(errorBuffer);
-        }
-        else
-        {
-            result = std::format("Unknown error ({}).", errorCode);
-        }
-
-        return result;
-    }
-
-    inline static bool GetDLLVersion(std::wstring dllPath)
-    {
-        // Step 1: Get the size of the version information
-        DWORD handle = 0;
-        DWORD versionSize = GetFileVersionInfoSize(dllPath.c_str(), &handle);
-
-        if (versionSize == 0)
-        {
-            LOG_ERROR("Failed to get version info size: {}", LogLastError());
-            return false;
-        }
-
-        // Step 2: Allocate buffer and get the version information
-        std::vector<BYTE> versionInfo(versionSize);
-        if (!GetFileVersionInfo(dllPath.c_str(), handle, versionSize, versionInfo.data()))
-        {
-            LOG_ERROR("Failed to get version info: {}", LogLastError());
-            return false;
-        }
-
-        // Step 3: Extract the version information
-        VS_FIXEDFILEINFO* fileInfo = nullptr;
-        UINT size = 0;
-        if (!VerQueryValue(versionInfo.data(), L"\\", reinterpret_cast<LPVOID*>(&fileInfo), &size)) {
-            LOG_ERROR("Failed to query version value: {}", LogLastError());
-            return false;
-        }
-
-        if (fileInfo != nullptr) {
-            // Extract major, minor, build, and revision numbers from version information
-            DWORD fileVersionMS = fileInfo->dwFileVersionMS;
-            DWORD fileVersionLS = fileInfo->dwFileVersionLS;
-
-            _xessVersion.major = (fileVersionMS >> 16) & 0xffff;
-            _xessVersion.minor = (fileVersionMS >> 0) & 0xffff;
-            _xessVersion.patch = (fileVersionLS >> 16) & 0xffff;
-            _xessVersion.reserved = (fileVersionLS >> 0) & 0xffff;
-        }
-        else
-        {
-            LOG_ERROR("No version information found!");
-            return false;
-        }
-
-        return true;
-    }
-
     inline static std::filesystem::path DllPath(HMODULE module)
     {
         static std::filesystem::path dll;
@@ -286,7 +216,7 @@ public:
             if (moduleHandle != nullptr)
             {
                 auto path = DllPath(moduleHandle);
-                if(!GetDLLVersion(path.wstring()))
+                if (!Util::GetDLLVersion(path.wstring(), &_xessVersion))
                     _xessGetVersion(&_xessVersion);
             }
             else

--- a/OptiScaler/dllmain.cpp
+++ b/OptiScaler/dllmain.cpp
@@ -606,8 +606,8 @@ static HMODULE LoadNvgxDlss(std::wstring originalPath)
 
 static FARPROC hkGetProcAddress(HMODULE hModule, LPCSTR lpProcName)
 {
-    //if (hModule == dllModule)
-    //    LOG_DEBUG("Trying to get process address of {0}", lpProcName);
+    if (hModule == dllModule)
+        LOG_DEBUG("Trying to get process address of {0}", lpProcName);
 
     if (hModule == GetModuleHandle(L"gdi32.dll") && lstrcmpA(lpProcName, "D3DKMTEnumAdapters2") == 0 && Config::Instance()->IsRunningOnLinux)
         return (FARPROC)&customD3DKMTEnumAdapters2;

--- a/OptiScaler/hooks/HooksDx.cpp
+++ b/OptiScaler/hooks/HooksDx.cpp
@@ -2084,6 +2084,8 @@ static HRESULT Present(IDXGISwapChain* pSwapChain, UINT SyncInterval, UINT Flags
         }
     }
 
+    ReflexHooks::update(FrameGen_Dx12::fgIsActive);
+
     // Upscaler GPU time computation
     if (HooksDx::dx12UpscaleTrig && HooksDx::readbackBuffer != nullptr && HooksDx::queryHeap != nullptr && cq != nullptr)
     {
@@ -2210,8 +2212,6 @@ static HRESULT Present(IDXGISwapChain* pSwapChain, UINT SyncInterval, UINT Flags
 
     if (Config::Instance()->CurrentFeature != nullptr)
         fgPresentedFrame = Config::Instance()->CurrentFeature->FrameCount();
-
-    ReflexHooks::update(FrameGen_Dx12::fgIsActive);
 
     // release used objects
     if (cq != nullptr)

--- a/OptiScaler/hooks/wrapped_swapchain.cpp
+++ b/OptiScaler/hooks/wrapped_swapchain.cpp
@@ -117,11 +117,10 @@ HRESULT WrappedIDXGISwapChain4::ResizeBuffers(UINT BufferCount, UINT Width, UINT
     LOG_DEBUG("");
 
 #ifdef USE_LOCAL_MUTEX
-    if (_localMutex.isLocked()) {
-        LOG_TRACE("Mutex already locked");
-    }
-    if (!(_localMutex.getOwner() == 4 && Config::Instance()->DLSSGMod.value_or(false))) // dlssg calls this from present it seems
-        _localMutex.lock(1);
+    // dlssg calls this from present it seems
+    // don't try to get a mutex when present owns it while dlssg mod is enabled
+    if (!(_localMutex.getOwner() == 4 && Config::Instance()->DLSSGMod.value_or(false)))
+        OwnedLockGuard lock(_localMutex, 1);
 #endif
 
 #ifdef USE_MUTEX_FOR_FFX
@@ -225,8 +224,6 @@ HRESULT WrappedIDXGISwapChain4::ResizeBuffers(UINT BufferCount, UINT Width, UINT
         }
     }
 
-    if(_localMutex.getOwner() == 1)
-        _localMutex.unlock();
     LOG_DEBUG("result: {0:X}", (UINT)result);
     return result;
 }
@@ -242,11 +239,10 @@ HRESULT WrappedIDXGISwapChain4::ResizeBuffers1(UINT BufferCount, UINT Width, UIN
     LOG_DEBUG("");
 
 #ifdef USE_LOCAL_MUTEX
-    if (_localMutex.isLocked()) {
-        LOG_TRACE("Mutex already locked");
-    }
-    if (!(_localMutex.getOwner() == 4 && Config::Instance()->DLSSGMod.value_or(false))) // dlssg calls this from present it seems
-        _localMutex.lock(2);
+    // dlssg calls this from present it seems
+    // don't try to get a mutex when present owns it while dlssg mod is enabled
+    if (!(_localMutex.getOwner() == 4 && Config::Instance()->DLSSGMod.value_or(false)))
+        OwnedLockGuard lock(_localMutex, 2);
 #endif
 
 #ifdef USE_MUTEX_FOR_FFX
@@ -347,9 +343,6 @@ HRESULT WrappedIDXGISwapChain4::ResizeBuffers1(UINT BufferCount, UINT Width, UIN
         }
     }
 
-    if (_localMutex.getOwner() == 2)
-        _localMutex.unlock();
-
     LOG_DEBUG("result: {0:X}", (UINT)result);
 
     return result;
@@ -385,11 +378,10 @@ HRESULT WrappedIDXGISwapChain4::SetFullscreenState(BOOL Fullscreen, IDXGIOutput*
 
     {
 #ifdef USE_LOCAL_MUTEX
-        if (_localMutex.isLocked()) {
-            LOG_TRACE("Mutex already locked");
-        }
-        if (!(_localMutex.getOwner() == 4 && Config::Instance()->DLSSGMod.value_or(false))) // dlssg calls this from present it seems
-            _localMutex.lock(3);
+        // dlssg calls this from present it seems
+        // don't try to get a mutex when present owns it while dlssg mod is enabled
+        if (!(_localMutex.getOwner() == 4 && Config::Instance()->DLSSGMod.value_or(false)))
+            OwnedLockGuard lock(_localMutex, 3);
 #endif
 
 #ifdef USE_MUTEX_FOR_FFX
@@ -439,8 +431,7 @@ HRESULT WrappedIDXGISwapChain4::SetFullscreenState(BOOL Fullscreen, IDXGIOutput*
             }
         }
     }
-    if (_localMutex.getOwner() == 3)
-        _localMutex.unlock();
+
     return result;
 }
 
@@ -465,7 +456,7 @@ HRESULT WrappedIDXGISwapChain4::Present(UINT SyncInterval, UINT Flags)
         return DXGI_ERROR_DEVICE_REMOVED;
 
 #ifdef USE_LOCAL_MUTEX
-    _localMutex.lock(4);
+    OwnedLockGuard lock(_localMutex, 4);
 #endif
 
     HRESULT result;
@@ -475,7 +466,6 @@ HRESULT WrappedIDXGISwapChain4::Present(UINT SyncInterval, UINT Flags)
     else
         result = m_pReal->Present(SyncInterval, Flags);
 
-    _localMutex.unlock();
     return result;
 }
 
@@ -485,7 +475,7 @@ HRESULT WrappedIDXGISwapChain4::Present1(UINT SyncInterval, UINT Flags, const DX
         return DXGI_ERROR_DEVICE_REMOVED;
 
 #ifdef USE_LOCAL_MUTEX
-    _localMutex.lock(5);
+    OwnedLockGuard lock(_localMutex, 5);
 #endif
 
     HRESULT result;
@@ -495,7 +485,6 @@ HRESULT WrappedIDXGISwapChain4::Present1(UINT SyncInterval, UINT Flags, const DX
     else
         result = m_pReal1->Present1(SyncInterval, Flags, pPresentParameters);
 
-    _localMutex.unlock();
     return result;
 }
 

--- a/OptiScaler/hooks/wrapped_swapchain.h
+++ b/OptiScaler/hooks/wrapped_swapchain.h
@@ -13,10 +13,10 @@ typedef void(*PFN_SC_Clean)(bool, HWND);
 typedef void(*PFN_SC_Release)(HWND);
 
 
-class DebugMutex {
+class OwnedMutex {
 private:
     std::mutex mtx;
-    uint32_t owner; // don't use 0
+    uint32_t owner{}; // don't use 0
 
 public:
     void lock(uint32_t _owner) {
@@ -24,23 +24,31 @@ public:
         owner = _owner;
     }
 
-    void unlock() {
-        mtx.unlock();
-        owner = 0;
-    }
-
-    bool isLocked() {
-        if (mtx.try_lock()) {
+    // Only unlocks if owner matches
+    void unlockThis(uint32_t _owner) {
+        if (owner == _owner) {
             mtx.unlock();
-            return false;
-        }
-        else {
-            return true;
+            owner = 0;
         }
     }
 
     uint32_t getOwner() {
         return owner;
+    }
+};
+
+class OwnedLockGuard {
+private:
+    OwnedMutex& _mutex;
+    uint32_t _owner_id;
+
+public:
+    OwnedLockGuard(OwnedMutex &mutex, uint32_t owner_id) : _mutex(mutex),  _owner_id(owner_id) {
+        _mutex.lock(_owner_id);
+    }
+
+    ~OwnedLockGuard() {
+        _mutex.unlockThis(_owner_id);
     }
 };
 
@@ -300,7 +308,7 @@ struct DECLSPEC_UUID("3af622a3-82d0-49cd-994f-cce05122c222") WrappedIDXGISwapCha
     HWND Handle = nullptr;
 
 #ifdef USE_LOCAL_MUTEX
-    DebugMutex _localMutex;
+    OwnedMutex _localMutex;
 #endif 
 
     int id = 0;

--- a/OptiScaler/imgui/imgui_common.cpp
+++ b/OptiScaler/imgui/imgui_common.cpp
@@ -1604,12 +1604,12 @@ bool ImGuiCommon::RenderMenu()
                         if (ImGui::SliderFloat("Camera Near", &cameraNear, 0.1f, 500000.0f, "%.1f", ImGuiSliderFlags_NoRoundToFormat))
                             Config::Instance()->FsrCameraNear = cameraNear;
                         ShowHelpMarker("Might help achieve better image quality\n"
-                            "And potentially less ghosting");
+                                       "And potentially less ghosting");
 
                         if (ImGui::SliderFloat("Camera Far", &cameraFar, 0.1f, 500000.0f, "%.1f", ImGuiSliderFlags_NoRoundToFormat))
                             Config::Instance()->FsrCameraFar = cameraFar;
                         ShowHelpMarker("Might help achieve better image quality\n"
-                            "And potentially less ghosting");
+                                       "And potentially less ghosting");
 
                         if (ImGui::Button("Reset Camera Values"))
                         {
@@ -1619,8 +1619,8 @@ bool ImGuiCommon::RenderMenu()
 
                         ImGui::SameLine(0.0f, 6.0f);
                         ImGui::Text("Near: %.1f Far: %.1f",
-                            Config::Instance()->LastFsrCameraNear < 500000.0f ? Config::Instance()->LastFsrCameraNear : 500000.0f,
-                            Config::Instance()->LastFsrCameraFar < 500000.0f ? Config::Instance()->LastFsrCameraFar : 500000.0f);
+                                    Config::Instance()->LastFsrCameraNear < 500000.0f ? Config::Instance()->LastFsrCameraNear : 500000.0f,
+                                    Config::Instance()->LastFsrCameraFar < 500000.0f ? Config::Instance()->LastFsrCameraFar : 500000.0f);
                     }
 
                     // DLSS -----------------
@@ -1632,7 +1632,7 @@ bool ImGuiCommon::RenderMenu()
                         if (bool pOverride = Config::Instance()->RenderPresetOverride.value_or(false); ImGui::Checkbox("Render Presets Override", &pOverride))
                             Config::Instance()->RenderPresetOverride = pOverride;
                         ShowHelpMarker("Each render preset has it strengths and weaknesses\n"
-                            "Override to potentially improve image quality");
+                                       "Override to potentially improve image quality");
 
                         ImGui::SameLine(0.0f, 6.0f);
 
@@ -1660,11 +1660,8 @@ bool ImGuiCommon::RenderMenu()
                         ImGui::SeparatorText("RCAS Settings");
 
                         // xess or dlss version >= 2.5.1
-                        rcasEnabled = (currentBackend == "xess" || (currentBackend == "dlss" &&
-                            (Config::Instance()->CurrentFeature->Version().major > 2 ||
-                                (Config::Instance()->CurrentFeature->Version().major == 2 &&
-                                    Config::Instance()->CurrentFeature->Version().minor >= 5 &&
-                                    Config::Instance()->CurrentFeature->Version().patch >= 1))));
+                        constexpr feature_version requiredDlssVersion = { 2, 5, 1 };
+                        rcasEnabled = (currentBackend == "xess" || (currentBackend == "dlss" && isVersionOrBetter(Config::Instance()->CurrentFeature->Version(), requiredDlssVersion)));
 
                         if (bool rcas = Config::Instance()->RcasEnabled.value_or(rcasEnabled); ImGui::Checkbox("Enable RCAS", &rcas))
                             Config::Instance()->RcasEnabled = rcas;

--- a/OptiScaler/nvapi/fakenvapi.h
+++ b/OptiScaler/nvapi/fakenvapi.h
@@ -54,7 +54,7 @@ public:
 
     // Inform AntiLag 2 when present of interpolated frames starts
     inline static void reportFGPresent(IDXGISwapChain* pSwapChain, bool fg_state, bool frame_interpolated) {
-        if (Fake_InformFGState == nullptr || Fake_InformPresentFG == nullptr || Fake_GetAntiLagCtx == nullptr) return;
+        if (Fake_InformFGState == nullptr || Fake_InformPresentFG == nullptr) return;
 
         // Lets fakenvapi log and reset correctly
         Fake_InformFGState(fg_state);
@@ -64,9 +64,11 @@ public:
             // and it will call SetFrameGenFrameType for us
             auto static ffxApiVersion = FfxApiProxy::VersionDx12();
             constexpr feature_version requiredVersion = { 3, 1, 1 };
-            if (isVersionOrBetter(ffxApiVersion, requiredVersion)) {
+            //constexpr feature_version requiredVersion = { 4, 0, 0 };
+            if (isVersionOrBetter(ffxApiVersion, requiredVersion) && Fake_GetAntiLagCtx != nullptr) {
                 void* antilag2Context = nullptr;
                 Fake_GetAntiLagCtx(&antilag2Context);
+                LOG_TRACE("Fake_GetAntiLagCtx: {}", antilag2Context != nullptr);
 
                 if (antilag2Context != nullptr) {
                     antilag2_data.context = antilag2Context;
@@ -79,6 +81,7 @@ public:
             {
                 // Tell fakenvapi to call SetFrameGenFrameType by itself
                 // Reflex frame id might get used in the future
+                LOG_TRACE("Fake_InformPresentFG: {}", frame_interpolated);
                 Fake_InformPresentFG(frame_interpolated, 0);
             }
         }

--- a/OptiScaler/nvapi/fakenvapi.h
+++ b/OptiScaler/nvapi/fakenvapi.h
@@ -64,7 +64,6 @@ public:
             // and it will call SetFrameGenFrameType for us
             auto static ffxApiVersion = FfxApiProxy::VersionDx12();
             constexpr feature_version requiredVersion = { 3, 1, 1 };
-            //constexpr feature_version requiredVersion = { 4, 0, 0 };
             if (isVersionOrBetter(ffxApiVersion, requiredVersion) && Fake_GetAntiLagCtx != nullptr) {
                 void* antilag2Context = nullptr;
                 Fake_GetAntiLagCtx(&antilag2Context);

--- a/external/streamline/sl.h
+++ b/external/streamline/sl.h
@@ -1,0 +1,904 @@
+/*
+* Copyright (c) 2022-2023 NVIDIA CORPORATION. All rights reserved
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+
+#pragma once
+
+#include <limits.h>
+
+#include "sl_struct.h"
+#include "sl_consts.h"
+#include "sl_version.h"
+#include "sl_result.h"
+
+#define SL_API extern "C"
+#define SL_CHECK(f) {auto _r = f; if(_r != sl::Result::eOk) return _r;}
+#define SL_FAILED(r, f) sl::Result r = f; r != sl::Result::eOk
+#define SL_SUCCEEDED(r, f) sl::Result r = f; r == sl::Result::eOk
+#define SL_FUN_DECL(name) PFun_##name* name{}
+//! IMPORTANT: Macros which use `slGetFeatureFunction` can only be used AFTER device is set by calling either slSetD3DDevice or slSetVulkanInfo.
+#define SL_FEATURE_FUN_IMPORT(feature, func) slGetFeatureFunction(feature, #func, (void*&) ##func)
+#define SL_FEATURE_FUN_IMPORT_STATIC(feature, func)                             \
+static PFun_##func* s_ ##func{};                                                \
+if(!s_ ##func) {                                                                \
+    sl::Result res = slGetFeatureFunction(feature, #func, (void*&) s_ ##func);  \
+    if(res != sl::Result::eOk) return res;                                      \
+}                                                                               \
+
+typedef struct ID3D11Resource   ID3D11Resource;
+typedef struct ID3D11Buffer     ID3D11Buffer;
+typedef struct ID3D11Texture2D  ID3D11Texture2D;
+typedef struct ID3D12Resource   ID3D12Resource;
+
+namespace sl {
+
+using CommandBuffer = void;
+using Device = void;
+
+//! Buffer types used for tagging
+//! 
+//! IMPORTANT: Each tag must use the unique id
+//! 
+using BufferType = uint32_t;
+
+//! Depth buffer - IMPORTANT - Must be suitable to use with clipToPrevClip transformation (see Constants below)
+constexpr BufferType kBufferTypeDepth = 0;
+//! Object and optional camera motion vectors (see Constants below)
+constexpr BufferType kBufferTypeMotionVectors = 1;
+//! Color buffer with all post-processing effects applied but without any UI/HUD elements
+constexpr BufferType kBufferTypeHUDLessColor = 2;
+//! Color buffer containing jittered input data for the image scaling pass
+constexpr BufferType kBufferTypeScalingInputColor = 3;
+//! Color buffer containing results from the image scaling pass
+constexpr BufferType kBufferTypeScalingOutputColor = 4;
+//! Normals
+constexpr BufferType kBufferTypeNormals = 5;
+//! Roughness
+constexpr BufferType kBufferTypeRoughness = 6;
+//! Albedo
+constexpr BufferType kBufferTypeAlbedo = 7;
+//! Specular Albedo
+constexpr BufferType kBufferTypeSpecularAlbedo = 8;
+//! Indirect Albedo
+constexpr BufferType kBufferTypeIndirectAlbedo = 9;
+//! Specular Motion Vectors
+constexpr BufferType kBufferTypeSpecularMotionVectors = 10;
+//! Disocclusion Mask
+constexpr BufferType kBufferTypeDisocclusionMask = 11;
+//! Emissive
+constexpr BufferType kBufferTypeEmissive = 12;
+//! Exposure
+constexpr BufferType kBufferTypeExposure = 13;
+//! Buffer with normal and roughness in alpha channel
+constexpr BufferType kBufferTypeNormalRoughness = 14;
+//! Diffuse and camera ray length
+constexpr BufferType kBufferTypeDiffuseHitNoisy = 15;
+//! Diffuse denoised
+constexpr BufferType kBufferTypeDiffuseHitDenoised = 16;
+//! Specular and reflected ray length
+constexpr BufferType kBufferTypeSpecularHitNoisy = 17;
+//! Specular denoised
+constexpr BufferType kBufferTypeSpecularHitDenoised = 18;
+//! Shadow noisy
+constexpr BufferType kBufferTypeShadowNoisy = 19;
+//! Shadow denoised
+constexpr BufferType kBufferTypeShadowDenoised = 20;
+//! AO noisy
+constexpr BufferType kBufferTypeAmbientOcclusionNoisy = 21;
+//! AO denoised
+constexpr BufferType kBufferTypeAmbientOcclusionDenoised = 22;
+//! Optional - UI/HUD color and alpha
+//! IMPORTANT: Please make sure that alpha channel has enough precision (for example do NOT use formats like R10G10B10A2)
+constexpr BufferType kBufferTypeUIColorAndAlpha = 23;
+//! Optional - Shadow pixels hint (set to 1 if a pixel belongs to the shadow area, 0 otherwise)
+constexpr BufferType kBufferTypeShadowHint = 24;
+//! Optional - Reflection pixels hint (set to 1 if a pixel belongs to the reflection area, 0 otherwise)
+constexpr BufferType kBufferTypeReflectionHint = 25;
+//! Optional - Particle pixels hint (set to 1 if a pixel represents a particle, 0 otherwise)
+constexpr BufferType kBufferTypeParticleHint = 26;
+//! Optional - Transparency pixels hint (set to 1 if a pixel belongs to the transparent area, 0 otherwise)
+constexpr BufferType kBufferTypeTransparencyHint = 27;
+//! Optional - Animated texture pixels hint (set to 1 if a pixel belongs to the animated texture area, 0 otherwise)
+constexpr BufferType kBufferTypeAnimatedTextureHint = 28;
+//! Optional - Bias for current color vs history hint - lerp(history, current, bias) (set to 1 to completely reject history)
+constexpr BufferType kBufferTypeBiasCurrentColorHint = 29;
+//! Optional - Ray-tracing distance (camera ray length)
+constexpr BufferType kBufferTypeRaytracingDistance = 30;
+//! Optional - Motion vectors for reflections
+constexpr BufferType kBufferTypeReflectionMotionVectors = 31;
+//! Optional - Position, in same space as eNormals
+constexpr BufferType kBufferTypePosition = 32;
+//! Optional - Indicates (via non-zero value) which pixels have motion/depth values that do not match the final color content at that pixel (e.g. overlaid, opaque Picture-in-Picture)
+constexpr BufferType kBufferTypeInvalidDepthMotionHint = 33;
+//! Alpha
+constexpr BufferType kBufferTypeAlpha = 34;
+//! Color buffer containing only opaque geometry
+constexpr BufferType kBufferTypeOpaqueColor = 35;
+//! Optional - Reduce reliance on history instead using current frame hint (0 if a pixel is not at all reactive and default composition should be used, 1 if fully reactive)
+constexpr BufferType kBufferTypeReactiveMaskHint = 36;
+//! Optional - Pixel lock adjustment hint (set to 1 if pixel lock should be completely removed, 0 otherwise)
+constexpr BufferType kBufferTypeTransparencyAndCompositionMaskHint = 37;
+//! Optional - Albedo of the reflection ray hit point. For multibounce reflections, this should be the albedo of the first non-specular bounce.
+constexpr BufferType kBufferTypeReflectedAlbedo = 38;
+//! Optional - Color buffer before particles are drawn.
+constexpr BufferType kBufferTypeColorBeforeParticles = 39;
+//! Optional - Color buffer before transparent objects are drawn.
+constexpr BufferType kBufferTypeColorBeforeTransparency = 40;
+//! Optional - Color buffer before fog is drawn.
+constexpr BufferType kBufferTypeColorBeforeFog = 41;
+//! Optional - Buffer containing the hit distance of a specular ray.
+constexpr BufferType kBufferTypeSpecularHitDistance = 42;
+//! Optional - Buffer that contains 3 components of a specular ray direction, and 1 component of specular hit distance.
+constexpr BufferType kBufferTypeSpecularRayDirectionHitDistance = 43;
+//! Optional - Buffer containing normalized direction of a specular ray.
+constexpr BufferType kBufferTypeSpecularRayDirection = 44;
+// !Optional - Buffer containing the hit distance of a diffuse ray.
+constexpr BufferType kBufferTypeDiffuseHitDistance = 45;
+//! Optional - Buffer that contains 3 components of a diffuse ray direction, and 1 component of diffuse hit distance.
+constexpr BufferType kBufferTypeDiffuseRayDirectionHitDistance = 46;
+//! Optional - Buffer containing normalized direction of a diffuse ray.
+constexpr BufferType kBufferTypeDiffuseRayDirection = 47;
+//! Optional - Buffer containing display resolution depth.
+constexpr BufferType kBufferTypeHiResDepth = 48;
+//! Required either this or kBufferTypeDepth - Buffer containing linear depth.
+constexpr BufferType kBufferTypeLinearDepth = 49;
+//! Optional - Bidirectional distortion field. 4 channels in normalized [0,1] pixel space. RG = distorted pixel to undistorted pixel displacement. BA = undistorted pixel to distorted pixel displacement.
+constexpr BufferType kBufferTypeBidirectionalDistortionField = 50;
+//!Optional - Buffer containing particles or other similar transparent effects rendered into it instead of passing it as part of the input color
+constexpr BufferType kBufferTypeTransparencyLayer = 51;
+//!Optional - Butffer to be used in addition to TransparencyLayer which allows 3-channels of Opacity versus 1-channel. 
+//            In this case, TransparencyLayer represents Color (RcGcBc), TransparencyLayerOpacity represents alpha (RaGaBa)'
+constexpr BufferType kBufferTypeTransparencyLayerOpacity = 52;
+//! Optional - Swapchain buffer to be presented
+constexpr BufferType kBufferTypeBackbuffer = 53;
+
+//! Features supported with this SDK
+//! 
+//! IMPORTANT: Each feature must use a unique id
+//! 
+using Feature = uint32_t;
+
+//! Deep Learning Super Sampling
+constexpr Feature kFeatureDLSS = 0;
+
+//! Real-Time Denoiser
+constexpr Feature kFeatureNRD = 1;
+
+//! NVIDIA Image Scaling
+constexpr Feature kFeatureNIS = 2;
+
+//! Reflex
+constexpr Feature kFeatureReflex = 3;
+
+//! PC Latency
+constexpr Feature kFeaturePCL = 4;
+
+//! DeepDVC
+constexpr Feature kFeatureDeepDVC = 5;
+
+
+//! DLSS Frame Generation
+constexpr Feature kFeatureDLSS_G = 1000;
+
+//! DLSS Ray Reconstruction
+constexpr Feature kFeatureDLSS_RR = 1001;
+
+constexpr Feature kFeatureNvPerf = 1002;
+
+constexpr Feature kFeatureDirectSR = 1003;
+
+// ImGUI 
+constexpr Feature kFeatureImGUI = 9999;
+
+//! Common feature, NOT intended to be used directly
+constexpr Feature kFeatureCommon = UINT_MAX;
+
+//! Different levels for logging
+enum class LogLevel : uint32_t
+{
+    //! No logging
+    eOff,
+    //! Default logging
+    eDefault,
+    //! Verbose logging
+    eVerbose,
+    //! Total count
+    eCount
+};
+
+//! Resource types
+enum class ResourceType : char
+{
+    eTex2d,
+    eBuffer,
+    eCommandQueue,
+    eCommandBuffer,
+    eCommandPool,
+    eFence,
+    eSwapchain,
+    eHostFence,
+    eCount
+};
+
+//! Resource allocate information
+//!
+SL_STRUCT(ResourceAllocationDesc, StructType({ 0xbb57e5, 0x49a2, 0x4c23, { 0xa5, 0x19, 0xab, 0x92, 0x86, 0xe7, 0x40, 0x14 } }), kStructVersion1)
+    ResourceAllocationDesc(ResourceType _type, void* _desc, uint32_t _state, void* _heap) : BaseStructure(ResourceAllocationDesc::s_structType, kStructVersion1), type(_type),desc(_desc),state(_state),heap(_heap){};
+    //! Indicates the type of resource
+    ResourceType type = ResourceType::eTex2d;
+    //! D3D12_RESOURCE_DESC/VkImageCreateInfo/VkBufferCreateInfo
+    void* desc{};
+    //! Initial state as D3D12_RESOURCE_STATES or VkMemoryPropertyFlags
+    uint32_t state = 0;
+    //! CD3DX12_HEAP_PROPERTIES or nullptr
+    void* heap{};
+
+    //! IMPORTANT: New members go here or if optional can be chained in a new struct, see sl_struct.h for details
+};
+
+
+//! Subresource range information, for Vulkan resources
+//! 
+//! {8D4C316C-D402-4524-89A7-14E79E638E3A}
+SL_STRUCT(SubresourceRange, StructType({ 0x8d4c316c, 0xd402, 0x4524, { 0x89, 0xa7, 0x14, 0xe7, 0x9e, 0x63, 0x8e, 0x3a } }), kStructVersion1)
+    //! Vulkan subresource aspectMask
+    uint32_t aspectMask;
+    //! Vulkan subresource baseMipLevel
+    uint32_t baseMipLevel;
+    //! Vulkan subresource levelCount
+    uint32_t levelCount;
+    //! Vulkan subresource baseArrayLayer
+    uint32_t baseArrayLayer;
+    //! Vulkan subresource layerCount
+    uint32_t layerCount;
+};
+
+//! Native resource
+//! 
+//! {3A9D70CF-2418-4B72-8391-13F8721C7261}
+SL_STRUCT(Resource, StructType({ 0x3a9d70cf, 0x2418, 0x4b72, { 0x83, 0x91, 0x13, 0xf8, 0x72, 0x1c, 0x72, 0x61 } }), kStructVersion1)
+    //! Constructors
+    //! 
+    //! Resource type, native pointer are MANDATORY always
+    //! Resource state is MANDATORY unless using D3D11
+    //! Resource view, description etc. are MANDATORY only when using Vulkan
+    //! 
+    Resource(ResourceType _type, void* _native, void* _mem, void* _view, uint32_t _state = UINT_MAX) : BaseStructure(Resource::s_structType, kStructVersion1), type(_type), native(_native), memory(_mem), view(_view), state(_state){};
+    Resource(ResourceType _type, void* _native, uint32_t _state = UINT_MAX) : BaseStructure(Resource::s_structType, kStructVersion1), type(_type), native(_native), state(_state) {};
+
+    //! Conversion helpers for D3D
+    inline operator ID3D12Resource* () { return reinterpret_cast<ID3D12Resource*>(native); }
+    inline operator ID3D11Resource* () { return reinterpret_cast<ID3D11Resource*>(native); }
+    inline operator ID3D11Buffer* () { return reinterpret_cast<ID3D11Buffer*>(native); }
+    inline operator ID3D11Texture2D* () { return reinterpret_cast<ID3D11Texture2D*>(native); }
+
+    //! Indicates the type of resource
+    ResourceType type = ResourceType::eTex2d;
+    //! ID3D11Resource/ID3D12Resource/VkBuffer/VkImage
+    void* native{};
+    //! vkDeviceMemory or nullptr
+    void* memory{};
+    //! VkImageView/VkBufferView or nullptr
+    void* view{};
+    //! State as D3D12_RESOURCE_STATES or VkImageLayout
+    //! 
+    //! IMPORTANT: State is MANDATORY and needs to be correct when tagged resources are actually used.
+    //! 
+    uint32_t state = UINT_MAX;
+    //! Width in pixels
+    uint32_t width{};
+    //! Height in pixels
+    uint32_t height{};
+    //! Native format
+    uint32_t nativeFormat{};
+    //! Number of mip-map levels
+    uint32_t mipLevels{};
+    //! Number of arrays
+    uint32_t arrayLayers{};
+    //! Virtual address on GPU (if applicable)
+    uint64_t gpuVirtualAddress{};
+    //! VkImageCreateFlags
+    uint32_t flags;
+    //! VkImageUsageFlags
+    uint32_t usage{};
+    //! Reserved for internal use
+    uint32_t reserved{};
+
+    //! IMPORTANT: New members go here or if optional can be chained in a new struct, see sl_struct.h for details
+};
+
+//! Specifies life-cycle for the tagged resource
+//! 
+//! IMPORTANT: Use 'eOnlyValidNow' and 'eValidUntilEvaluate' ONLY when really needed since it can result in wasting VRAM if SL ends up making unnecessary copies.
+//! 
+//! If integrating features, like for example DLSS-G, which require tags to be 'eValidUntilPresent' please try to tag everything as 'eValidUntilPresent' first
+//! and only make modifications if upon visual inspection you notice that tags are corrupted when used during the Present frame call.
+enum ResourceLifecycle
+{
+    //! Resource can change, get destroyed or reused for other purposes after it is provided to SL
+    eOnlyValidNow,
+    //! Resource does NOT change, gets destroyed or reused for other purposes from the moment it is provided to SL until the frame is presented
+    eValidUntilPresent,
+    //! Resource does NOT change, gets destroyed or reused for other purposes from the moment it is provided to SL until after the slEvaluateFeature call has returned.
+    eValidUntilEvaluate
+};
+
+//! Tagged resource
+//! 
+//! {4C6A5AAD-B445-496C-87FF-1AF3845BE653}
+//! Extensions as part of the `next` ptr:
+//!     PrecisionInfo
+SL_STRUCT(ResourceTag, StructType({ 0x4c6a5aad, 0xb445, 0x496c, { 0x87, 0xff, 0x1a, 0xf3, 0x84, 0x5b, 0xe6, 0x53 } }), kStructVersion1)
+    ResourceTag(Resource* r, BufferType t, ResourceLifecycle l, const Extent* e = nullptr)
+        : BaseStructure(ResourceTag::s_structType, kStructVersion1), resource(r), type(t), lifecycle(l)
+    {
+        if (e) extent = *e;
+    };
+
+    //! Resource description
+    Resource* resource{};
+    //! Type of the tagged buffer
+    BufferType type{};
+    //! The life-cycle for the tag, if resource is volatile a valid command buffer must be specified
+    ResourceLifecycle lifecycle{};
+    //! The area of the tagged resource to use (if using the entire resource leave as null)
+    Extent extent{};
+
+    //! IMPORTANT: New members go here or if optional can be chained in a new struct, see sl_struct.h for details
+};
+
+// 
+//! Precision info, optional extension for ResourceTag.
+//! 
+//! {98F6E9BA-8D16-4831-A802-4D3B52FF26BF}
+//! Extensions as part of the `next` ptr:
+//!     ResourceTag
+SL_STRUCT(PrecisionInfo, StructType({ 0x98f6e9ba, 0x8d16, 0x4831, { 0xa8, 0x2, 0x4d, 0x3b, 0x52, 0xff, 0x26, 0xbf } }), kStructVersion1)
+    // Formula used to convert the low-precision data to high-precision
+    enum PrecisionFormula : uint32_t
+    {
+        eNoTransform = 0,           // hi = lo, essentially no conversion is done
+        eLinearTransform,           // hi = lo * scale + bias
+    };
+
+    PrecisionInfo(PrecisionInfo::PrecisionFormula formula, float bias, float scale)
+        : BaseStructure(PrecisionInfo::structType, kStructVersion1), conversionFormula(formula), bias(bias), scale(scale) {};
+    
+    static std::string getPrecisionFormulaAsStr(PrecisionFormula formula)
+    {
+        switch (formula)
+        {
+        case eNoTransform:
+            return "eNoTransform";
+        case eLinearTransform:
+            return "eLinearTransform";
+        default:
+            assert("Invalid PrecisionFormula" && false);
+            return "Unknown";
+        }
+    };
+
+    PrecisionFormula conversionFormula{ eNoTransform };
+    float bias{ 0.0f };
+    float scale{ 1.0f };
+
+    inline operator bool() const { return conversionFormula != eNoTransform; }
+    inline bool operator==(const PrecisionInfo& rhs) const
+    {
+        return conversionFormula == rhs.conversionFormula && bias == rhs.bias && scale == rhs.scale;
+    }
+    inline bool operator!=(const PrecisionInfo& rhs) const
+    {
+        return !operator==(rhs);
+    }
+};
+
+//! Resource allocation/deallocation callbacks
+//!
+//! Use these callbacks to gain full control over 
+//! resource life cycle and memory allocation tracking.
+//!
+//! @param device - Device to be used (vkDevice or ID3D11Device or ID3D12Device)
+//!
+//! IMPORTANT: Textures must have the pixel shader resource
+//! and the unordered access view flags set
+using PFun_ResourceAllocateCallback = Resource(const ResourceAllocationDesc* desc, void* device);
+using PFun_ResourceReleaseCallback = void(Resource* resource, void* device);
+
+//! Log type
+enum class LogType : uint32_t
+{
+    //! Controlled by LogLevel, SL can show more information in eLogLevelVerbose mode
+    eInfo,
+    //! Always shown regardless of LogLevel
+    eWarn,
+    eError,
+    //! Total count
+    eCount
+};
+
+//! Logging callback
+//!
+//! Use these callbacks to track messages posted in the log.
+//! If any of the SL methods returns false use eLogTypeError
+//! type to track down what went wrong and why.
+using PFun_LogMessageCallback = void(LogType type, const char* msg);
+
+//! Optional flags
+enum class PreferenceFlags : uint64_t
+{
+    //! Set by default - Disables command list state tracking - Host application is responsible for restoring CL state correctly after each 'slEvaluateFeature' call
+    eDisableCLStateTracking = 1 << 0,
+    //! Optional - Disables debug text on screen in development builds
+    eDisableDebugText = 1 << 1,
+    //! Optional - IMPORTANT: Only to be used in the advanced integration mode, see the 'manual hooking' programming guide for more details
+    eUseManualHooking = 1 << 2,
+    //! Optional - Enables downloading of Over The Air (OTA) updates for SL and NGX
+    //! This will invoke the OTA updater to look for new updates. A separate
+    //! flag below is used to control whether or not OTA-downloaded SL Plugins are
+    //! loaded.
+    eAllowOTA = 1 << 3,
+    //! Do not check OS version when deciding if feature is supported or not
+    //! 
+    //! IMPORTANT: ONLY SET THIS FLAG IF YOU KNOW WHAT YOU ARE DOING. 
+    //! 
+    //! VARIOUS WIN APIs INCLUDING BUT NOT LIMITED TO `IsWindowsXXX`, `GetVersionX`, `rtlGetVersion` ARE KNOWN FOR RETURNING INCORRECT RESULTS.
+    eBypassOSVersionCheck = 1 << 4,
+    //! Optional - If specified SL will create DXGI factory proxy rather than modifying the v-table for the base interface.
+    //! 
+    //! This can help with 3rd party overlays which are NOT integrated with the host application but rather operate via injection.
+    eUseDXGIFactoryProxy = 1 << 5,
+    //! Optional - Enables loading of plugins downloaded Over The Air (OTA), to
+    //! be used in conjunction with the eAllowOTA flag.
+    eLoadDownloadedPlugins = 1 << 6,
+};
+
+SL_ENUM_OPERATORS_64(PreferenceFlags)
+
+//! Engine types
+//! 
+enum class EngineType : uint32_t
+{
+    eCustom,
+    eUnreal,
+    eUnity,
+    eCount
+};
+
+//! Rendering API
+//! 
+enum class RenderAPI : uint32_t
+{
+    eD3D11,
+    eD3D12,
+    eVulkan,
+    eCount
+};
+
+//! Application preferences
+//!
+//! {1CA10965-BF8E-432B-8DA1-6716D879FB14}
+SL_STRUCT(Preferences, StructType({ 0x1ca10965, 0xbf8e, 0x432b, { 0x8d, 0xa1, 0x67, 0x16, 0xd8, 0x79, 0xfb, 0x14 } }), kStructVersion1)
+    //! Optional - In non-production builds it is useful to enable debugging console window
+    bool showConsole = false;
+    //! Optional - Various logging levels
+    LogLevel logLevel = LogLevel::eDefault;
+    //! Optional - Absolute paths to locations where to look for plugins, first path in the list has the highest priority
+    const wchar_t** pathsToPlugins{};
+    //! Optional - Number of paths to search
+    uint32_t numPathsToPlugins = 0;
+    //! Optional - Absolute path to location where logs and other data should be stored
+    //! 
+    //! NOTE: Set this to nullptr in order to disable logging to a file
+    const wchar_t* pathToLogsAndData{};
+    //! Optional - Allows resource allocation tracking on the host side
+    PFun_ResourceAllocateCallback* allocateCallback{};
+    //! Optional - Allows resource deallocation tracking on the host side
+    PFun_ResourceReleaseCallback* releaseCallback{};
+    //! Optional - Allows log message tracking including critical errors if they occur
+    PFun_LogMessageCallback* logMessageCallback{};
+    //! Optional - Flags used to enable or disable advanced options
+    PreferenceFlags flags = PreferenceFlags::eDisableCLStateTracking | PreferenceFlags::eAllowOTA | PreferenceFlags::eLoadDownloadedPlugins;
+    //! Required - Features to load (assuming appropriate plugins are found), if not specified NO features will be loaded by default
+    const Feature* featuresToLoad{};
+    //! Required - Number of features to load, only used when list is not a null pointer
+    uint32_t numFeaturesToLoad{};
+    //! Optional - Id provided by NVIDIA, if not specified then engine type and version are required
+    uint32_t applicationId{};
+    //! Optional - Type of the rendering engine used, if not specified then applicationId is required
+    EngineType engine = EngineType::eCustom;
+    //! Optional - Version of the rendering engine used
+    const char* engineVersion{};
+    //! Optional - GUID (like for example 'a0f57b54-1daf-4934-90ae-c4035c19df04')
+    const char* projectId{};
+    //! Optional - Which rendering API host is planning to use
+    //! 
+    //! NOTE: To ensure correct `slGetFeatureRequirements` behavior please specify if planning to use Vulkan.
+    RenderAPI renderAPI = RenderAPI::eD3D12;
+
+    //! IMPORTANT: New members go here or if optional can be chained in a new struct, see sl_struct.h for details
+};
+
+//! Frame tracking handle
+//! 
+//! IMPORTANT: Use slGetNewFrameToken to obtain unique instance
+//! 
+//! {830A0F35-DB84-4171-A804-59B206499B18}
+SL_STRUCT_PROTECTED(FrameToken, StructType({ 0x830a0f35, 0xdb84, 0x4171, { 0xa8, 0x4, 0x59, 0xb2, 0x6, 0x49, 0x9b, 0x18 } }), kStructVersion1)
+    //! Helper operator to obtain current frame index
+    virtual operator uint32_t() const = 0;
+};
+
+//! Handle for the unique viewport
+//! 
+//! {171B6435-9B3C-4FC8-9994-FBE52569AAA4}
+SL_STRUCT(ViewportHandle, StructType({ 0x171b6435, 0x9b3c, 0x4fc8, { 0x99, 0x94, 0xfb, 0xe5, 0x25, 0x69, 0xaa, 0xa4 } }), kStructVersion1)
+    ViewportHandle(uint32_t v) : BaseStructure(ViewportHandle::s_structType, kStructVersion1), value(v) {}
+    ViewportHandle(int32_t v) : BaseStructure(ViewportHandle::s_structType, kStructVersion1), value(v) {}
+    operator uint32_t() const { return value; }
+private:
+    uint32_t value = UINT_MAX;
+};
+
+//! Specifies feature requirement flags
+//! 
+enum class FeatureRequirementFlags : uint32_t
+{
+    //! Rendering APIs
+    eD3D11Supported = 1 << 0,
+    eD3D12Supported = 1 << 1,
+    eVulkanSupported = 1 << 2,
+    //! If set V-Sync must be disabled when feature is active
+    eVSyncOffRequired = 1 << 3,
+    //! If set GPU hardware scheduling OS feature must be turned on
+    eHardwareSchedulingRequired = 1 << 4
+};
+
+SL_ENUM_OPERATORS_32(FeatureRequirementFlags);
+
+//! Specifies feature requirements
+//! 
+//! {66714097-AC6D-4BC6-8915-1E0F55A6B61F}
+SL_STRUCT(FeatureRequirements, StructType({ 0x66714097, 0xac6d, 0x4bc6, { 0x89, 0x15, 0x1e, 0xf, 0x55, 0xa6, 0xb6, 0x1f } }), kStructVersion2)
+    //! Various Flags
+    FeatureRequirementFlags flags {};
+    
+    //! Feature will create this many CPU threads
+    uint32_t maxNumCPUThreads{};
+
+    //! Feature supports only this many viewports
+    uint32_t maxNumViewports{};
+    
+    //! Required buffer tags
+    uint32_t numRequiredTags{};
+    const BufferType* requiredTags{};
+
+    //! OS and Driver versions
+    Version osVersionDetected{};
+    Version osVersionRequired{};
+    Version driverVersionDetected{};
+    Version driverVersionRequired{};
+
+    //! Vulkan specific bits
+    
+    //! Command queues
+    uint32_t vkNumComputeQueuesRequired{};
+    uint32_t vkNumGraphicsQueuesRequired{};
+    
+    //! Device extensions
+    uint32_t vkNumDeviceExtensions{};
+    const char** vkDeviceExtensions{};
+    //! Instance extensions
+    uint32_t vkNumInstanceExtensions{};
+    const char** vkInstanceExtensions{};
+    //! 1.2 features
+    //! 
+    //! NOTE: Use getVkPhysicalDeviceVulkan12Features from sl_helpers_vk.h
+    uint32_t vkNumFeatures12{};
+    const char** vkFeatures12{};
+    //! 1.3 features
+    //! 
+    //! NOTE: Use getVkPhysicalDeviceVulkan13Features from sl_helpers_vk.h
+    uint32_t vkNumFeatures13{};
+    const char** vkFeatures13{};
+
+    //! Vulkan optical flow feature
+    uint32_t vkNumOpticalFlowQueuesRequired{};
+
+    //! IMPORTANT: New members go here or if optional can be chained in a new struct, see sl_struct.h for details
+};
+
+//! Specifies feature's version
+//! 
+//! {6D5B51F0-076B-486D-9995-5A561043F5C1}
+SL_STRUCT(FeatureVersion, StructType({ 0x6d5b51f0, 0x76b, 0x486d, { 0x99, 0x95, 0x5a, 0x56, 0x10, 0x43, 0xf5, 0xc1 } }), kStructVersion1)
+    //! SL version
+    Version versionSL{};
+    //! NGX version (if feature is using NGX, null otherwise)
+    Version versionNGX{};
+
+    //! IMPORTANT: New members go here or if optional can be chained in a new struct, see sl_struct.h for details
+};
+
+//! Specifies either DXGI adapter or VK physical device
+//! 
+//! {0677315F-A746-4492-9F42-CB6142C9C3D4}
+SL_STRUCT(AdapterInfo, StructType({ 0x677315f, 0xa746, 0x4492, { 0x9f, 0x42, 0xcb, 0x61, 0x42, 0xc9, 0xc3, 0xd4 } }), kStructVersion1)
+    //! Locally unique identifier
+    uint8_t* deviceLUID {};
+    //! Size in bytes
+    uint32_t deviceLUIDSizeInBytes{};
+    //! Vulkan Specific, if specified LUID will be ignored
+    void* vkPhysicalDevice{};
+
+    //! IMPORTANT: New members go here or if optional can be chained in a new struct, see sl_struct.h for details
+};
+
+}
+
+//! Streamline core API functions (check feature specific headers for additional APIs)
+//! 
+using PFun_slInit = sl::Result(const sl::Preferences& pref, uint64_t sdkVersion);
+using PFun_slShutdown = sl::Result();
+using PFun_slIsFeatureSupported = sl::Result(sl::Feature feature, const sl::AdapterInfo& adapterInfo);
+using PFun_slIsFeatureLoaded = sl::Result(sl::Feature feature, bool& loaded);
+using PFun_slSetFeatureLoaded = sl::Result(sl::Feature feature, bool loaded);
+using PFun_slEvaluateFeature = sl::Result(sl::Feature feature, const sl::FrameToken& frame, const sl::BaseStructure** inputs, uint32_t numInputs, sl::CommandBuffer* cmdBuffer);
+using PFun_slAllocateResources = sl::Result(sl::CommandBuffer* cmdBuffer, sl::Feature feature, const sl::ViewportHandle& viewport);
+using PFun_slFreeResources = sl::Result(sl::Feature feature, const sl::ViewportHandle& viewport);
+using PFun_slSetTag = sl::Result(const sl::ViewportHandle& viewport, const sl::ResourceTag* tags, uint32_t numTags, sl::CommandBuffer* cmdBuffer);
+using PFun_slGetFeatureRequirements = sl::Result(sl::Feature feature, sl::FeatureRequirements& requirements);
+using PFun_slGetFeatureVersion = sl::Result(sl::Feature feature, sl::FeatureVersion& version);
+using PFun_slUpgradeInterface = sl::Result(void** baseInterface);
+using PFun_slSetConstants = sl::Result(const sl::Constants& values, const sl::FrameToken& frame, const sl::ViewportHandle& viewport);
+using PFun_slGetNativeInterface = sl::Result(void* proxyInterface, void** baseInterface);
+using PFun_slGetFeatureFunction = sl::Result(sl::Feature feature, const char* functionName, void*& function);
+using PFun_slGetNewFrameToken = sl::Result(sl::FrameToken*& token, uint32_t* frameIndex);
+using PFun_slSetD3DDevice = sl::Result(void* d3dDevice);
+
+//! Initializes the SL module
+//!
+//! Call this method when the game is initializing. 
+//!
+//! @param pref Specifies preferred behavior for the SL library (SL will keep a copy)
+//! @param sdkVersion Current SDK version
+//! @return sl::ResultCode::eOk if successful, error code otherwise (see sl_result.h for details)
+//!
+//! This method is NOT thread safe.
+SL_API sl::Result slInit(const sl::Preferences &pref, uint64_t sdkVersion = sl::kSDKVersion);
+
+//! Shuts down the SL module
+//!
+//! Call this method when the game is shutting down. 
+//!
+//! @return sl::ResultCode::eOk if successful, error code otherwise (see sl_result.h for details)
+//!
+//! This method is NOT thread safe.
+SL_API sl::Result slShutdown();
+
+//! Checks if a specific feature is supported or not.
+//!
+//! Call this method to check if a certain e* (see above) is available.
+//!
+//! @param feature Specifies which feature to use
+//! @param adapterInfo Adapter to check (optional)
+//! @return sl::ResultCode::eOk if successful, error code otherwise (see sl_result.h for details)
+//!
+//! NOTE: If adapter info is null SL will return general feature compatibility with the OS,
+//! installed drivers or any other requirements not directly related to the adapter.
+//! 
+//! This method is NOT thread safe.
+SL_API sl::Result slIsFeatureSupported(sl::Feature feature, const sl::AdapterInfo& adapterInfo);
+
+//! Checks if specified feature is loaded or not.
+//!
+//! Call this method to check if feature is loaded.
+//! All requested features are loaded by default and have to be unloaded explicitly if needed.
+//!
+//! @param feature Specifies which feature to check
+//! @param loaded Value specifying if feature is loaded or unloaded.
+//! @return sl::ResultCode::eOk if successful, error code otherwise (see sl_result.h for details)
+//!
+//! This method is NOT thread safe and requires DX/VK device to be created before calling it.
+SL_API sl::Result slIsFeatureLoaded(sl::Feature feature, bool& loaded);
+
+//! Sets the specified feature to either loaded or unloaded state.
+//!
+//! Call this method to load or unload certain e*. 
+//!
+//! NOTE: All requested features are loaded by default and have to be unloaded explicitly if needed.
+//!
+//! @param feature Specifies which feature to check
+//! @param loaded Value specifying if feature should be loaded or unloaded.
+//! @return sl::ResultCode::eOk if successful, error code otherwise (see sl_result.h for details)
+//!
+//! NOTE: When this method is called no other DXGI/D3D/Vulkan APIs should be invoked in parallel so
+//! make sure to flush your pipeline before calling this method.
+//!
+//! This method is NOT thread safe and requires DX/VK device to be created before calling it.
+SL_API sl::Result slSetFeatureLoaded(sl::Feature feature, bool loaded);
+
+//! Tags resource globally
+//!
+//! Call this method to tag the appropriate buffers in global scope.
+//!
+//! @param viewport Specifies viewport this tag applies to
+//! @param tags Pointer to resources tags, set to null to remove the specified tag
+//! @param numTags Number of resource tags in the provided list
+//! @param cmdBuffer Command buffer to use (optional and can be null if ALL tags are null or have eValidUntilPresent life-cycle)
+//! @return sl::ResultCode::eOk if successful, error code otherwise (see sl_result.h for details)
+//!
+//! IMPORTANT: GPU payload that generates content for the provided tag(s) MUST be either already submitted to the provided command buffer 
+//! or some other command buffer which is guaranteed, by the host application, to be executed BEFORE the provided command buffer.
+//! 
+//! This method is thread safe and requires DX/VK device to be created before calling it.
+SL_API sl::Result slSetTag(const sl::ViewportHandle& viewport, const sl::ResourceTag* tags, uint32_t numTags, sl::CommandBuffer* cmdBuffer);
+
+//! Sets common constants.
+//!
+//! Call this method to provide the required data (SL will keep a copy).
+//!
+//! @param values Common constants required by SL plugins (SL will keep a copy)
+//! @param frame Index of the current frame
+//! @param viewport Unique id (can be viewport id | instance id etc.)
+//! @return sl::ResultCode::eOk if successful, error code otherwise (see sl_result.h for details)
+//! 
+//! This method is thread safe and requires DX/VK device to be created before calling it.
+SL_API sl::Result slSetConstants(const sl::Constants& values, const sl::FrameToken& frame, const sl::ViewportHandle& viewport);
+
+//! Returns feature's requirements
+//!
+//! Call this method to check what is required to run certain eFeature* (see above).
+//! This method must be called after init otherwise it will always return an error.
+//!
+//! @param feature Specifies which feature to check
+//! @param requirements Data structure with feature's requirements
+//! @return sl::ResultCode::eOk if successful, error code otherwise (see sl_result.h for details)
+//!
+//! This method is NOT thread safe.
+SL_API sl::Result slGetFeatureRequirements(sl::Feature feature, sl::FeatureRequirements& requirements);
+
+//! Returns feature's version
+//!
+//! Call this method to check version for a certain eFeature* (see above).
+//! This method must be called after init otherwise it will always return an error.
+//!
+//! @param feature Specifies which feature to check
+//! @param version Data structure with feature's version
+//! @return sl::ResultCode::eOk if successful, error code otherwise (see sl_result.h for details)
+//!
+//! This method is thread safe.
+SL_API sl::Result slGetFeatureVersion(sl::Feature feature, sl::FeatureVersion& version);
+
+//! Allocates resources for the specified feature.
+//!
+//! Call this method to explicitly allocate resources
+//! for an instance of the specified feature.
+//! 
+//! @param cmdBuffer Command buffer to use (must be created on device where feature is supported but can be null if not needed)
+//! @param feature Feature we are working with
+//! @param viewport Unique id (viewport handle)
+//! @return sl::ResultCode::eOk if successful, error code otherwise (see sl_result.h for details)
+//!
+//! This method is NOT thread safe and requires DX/VK device to be created before calling it.
+SL_API sl::Result slAllocateResources(sl::CommandBuffer* cmdBuffer, sl::Feature feature, const sl::ViewportHandle& viewport);
+
+//! Frees resources for the specified feature.
+//!
+//! Call this method to explicitly free resources
+//! for an instance of the specified feature.
+//! 
+//! @param feature Feature we are working with
+//! @param viewport Unique id (viewport handle)
+//! @return sl::ResultCode::eOk if successful, error code otherwise (see sl_result.h for details)
+//!
+//! IMPORTANT: If slEvaluateFeature is pending on a command list, that command list must be flushed
+//! before calling this method to prevent invalid resource access on the GPU.
+//!
+//! IMPORTANT: If slEvaluateFeature is pending on a command list, that command list must be flushed
+//! before calling this method to prevent invalid resource access on the GPU.
+//!
+//! This method is NOT thread safe and requires DX/VK device to be created before calling it.
+SL_API sl::Result slFreeResources(sl::Feature feature, const sl::ViewportHandle& viewport);
+
+//! Evaluates feature
+//! 
+//! Use this method to mark the section in your rendering pipeline
+//! where specific feature should be injected.
+//!
+//! @param feature Feature we are working with
+//! @param frame Current frame handle obtained from SL
+//! @param inputs The chained structures providing the input data (viewport, tags, constants etc)
+//! @param numInputs Number of inputs
+//! @param cmdBuffer Command buffer to use (must be created on device where feature is supported)
+//! @return sl::ResultCode::eOk if successful, error code otherwise (see sl_result.h for details)
+//! 
+//! IMPORTANT: Frame and viewport must match whatever is used to set common and or feature options and constants (if any)
+//! 
+//! NOTE: It is allowed to pass in buffer tags as inputs, they are considered to be a "local" tags and do NOT interact with
+//! same tags sent in the global scope using slSetTag API.
+//!
+//! This method is NOT thread safe and requires DX/VK device to be created before calling it.
+SL_API sl::Result slEvaluateFeature(sl::Feature feature, const sl::FrameToken& frame, const sl::BaseStructure** inputs, uint32_t numInputs, sl::CommandBuffer* cmdBuffer);
+
+//! Upgrade interface
+//! 
+//! Use this method to upgrade basic D3D or DXGI interface to an SL proxy.
+//! 
+//! @param baseInterface Pointer to a pointer to the base interface (for example ID3D12Device etc.) to be replaced in place.
+//! @return sl::ResultCode::eOk if successful, error code otherwise (see sl_result.h for details)
+//! 
+//! IMPORTANT: This method should ONLY be used to support 3rd party SDKs like AMD AGS
+//! which bypass SL or when using manual hooking.
+//!
+//! This method is NOT thread safe and should be called IMMEDIATELY after base interface is created.
+SL_API sl::Result slUpgradeInterface(void** baseInterface);
+
+//! Obtain native interface
+//! 
+//! Use this method to obtain underlying D3D or DXGI interface from an SL proxy.
+//! 
+//! IMPORTANT: When calling NVAPI or other 3rd party SDKs from your application 
+//! it is recommended to provide native interfaces instead of SL proxies.
+//! 
+//! @param proxyInterface Pointer to the SL proxy (D3D device, swap-chain etc)
+//! @param baseInterface Pointer to a pointer to the base interface be returned.
+//! @return sl::ResultCode::eOk if successful, error code otherwise (see sl_result.h for details)
+//! 
+//! This method is NOT thread safe
+SL_API sl::Result slGetNativeInterface(void* proxyInterface, void** baseInterface);
+
+//! Gets specific feature's function
+//!
+//! Call this method to obtain various functions for the specified feature. See sl_$feature.h for details.
+//!
+//! @param feature Feature we are working with
+//! @param functionName The name of the API to obtain (declared in sl_[$feature].h
+//! @param function Pointer to the function to return
+//! @return sl::ResultCode::eOk if successful, error code otherwise (see sl_result.h for details)
+//! 
+//! IMPORTANT: Must be called AFTER device is set by calling either slSetD3DDevice or slSetVulkanInfo.
+//!
+//! This method is thread safe.
+SL_API sl::Result slGetFeatureFunction(sl::Feature feature, const char* functionName, void*& function);
+
+//! Gets unique frame token
+//!
+//! Call this method to obtain token for the unique frame identification.
+//!
+//! @param handle Frame token to return
+//! @param frameIndex Frame index (optional, if not provided SL internal frame counting is used)
+//! @return sl::ResultCode::eOk if successful, error code otherwise (see sl_result.h for details)
+//! 
+//! NOTE: Normally SL would not expect more that 3 frames in flight due to added latency.
+//!
+//! This method is thread safe.
+SL_API sl::Result slGetNewFrameToken(sl::FrameToken*& token, const uint32_t* frameIndex = nullptr);
+
+//! Set D3D device to use
+//! 
+//! Use this method to specify which D3D device should be used.
+//! 
+//! @param d3dDevice D3D device to use
+//! @return sl::ResultCode::eOk if successful, error code otherwise (see sl_result.h for details)
+//!
+//! This method is NOT thread safe and should be called IMMEDIATELY after main device is created.
+SL_API sl::Result slSetD3DDevice(void* d3dDevice);

--- a/external/streamline/sl_consts.h
+++ b/external/streamline/sl_consts.h
@@ -1,0 +1,250 @@
+/*
+* Copyright (c) 2022-2023 NVIDIA CORPORATION. All rights reserved
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/ 
+
+#pragma once
+
+#include <stdint.h>
+#include <assert.h>
+#include <string>
+#include "sl_struct.h"
+
+#define SL_ENUM_OPERATORS_64(T)                                                         \
+inline bool operator&(T a, T b)                                                         \
+{                                                                                       \
+    return ((uint64_t)a & (uint64_t)b) != 0;                                            \
+}                                                                                       \
+                                                                                        \
+inline T& operator&=(T& a, T b)                                                         \
+{                                                                                       \
+    a = (T)((uint64_t)a & (uint64_t)b);                                                 \
+    return a;                                                                           \
+}                                                                                       \
+                                                                                        \
+inline T operator|(T a, T b)                                                            \
+{                                                                                       \
+    return (T)((uint64_t)a | (uint64_t)b);                                              \
+}                                                                                       \
+                                                                                        \
+inline T& operator |= (T& lhs, T rhs)                                                   \
+{                                                                                       \
+    lhs = (T)((uint64_t)lhs | (uint64_t)rhs);                                           \
+    return lhs;                                                                         \
+}                                                                                       \
+                                                                                        \
+inline T operator~(T a)                                                                 \
+{                                                                                       \
+    return (T)~((uint64_t)a);                                                           \
+}
+
+#define SL_ENUM_OPERATORS_32(T)                                                         \
+inline bool operator&(T a, T b)                                                         \
+{                                                                                       \
+    return ((uint32_t)a & (uint32_t)b) != 0;                                            \
+}                                                                                       \
+                                                                                        \
+inline T& operator&=(T& a, T b)                                                         \
+{                                                                                       \
+    a = (T)((uint32_t)a & (uint32_t)b);                                                 \
+    return a;                                                                           \
+}                                                                                       \
+                                                                                        \
+inline T operator|(T a, T b)                                                            \
+{                                                                                       \
+    return (T)((uint32_t)a | (uint32_t)b);                                              \
+}                                                                                       \
+                                                                                        \
+inline T& operator |= (T& lhs, T rhs)                                                   \
+{                                                                                       \
+    lhs = (T)((uint32_t)lhs | (uint32_t)rhs);                                           \
+    return lhs;                                                                         \
+}                                                                                       \
+                                                                                        \
+inline T operator~(T a)                                                                 \
+{                                                                                       \
+    return (T)~((uint32_t)a);                                                           \
+}
+
+namespace sl
+{
+
+//! For cases when value has to be provided and we don't have good default
+constexpr float INVALID_FLOAT = 3.40282346638528859811704183484516925440e38f;
+constexpr uint32_t INVALID_UINT = 0xffffffff;
+
+struct uint3
+{
+    uint32_t x;
+    uint32_t y;
+    uint32_t z;
+};
+
+struct float2
+{
+    float2() : x(INVALID_FLOAT), y(INVALID_FLOAT) {}
+    float2(float _x, float _y) : x(_x), y(_y) {}
+    float x, y;
+};
+
+struct float3
+{
+    float3() : x(INVALID_FLOAT), y(INVALID_FLOAT), z(INVALID_FLOAT) {}
+    float3(float _x, float _y, float _z) : x(_x), y(_y), z(_z) {}
+    float x, y, z;
+};
+
+struct float4
+{
+    float4() : x(INVALID_FLOAT), y(INVALID_FLOAT), z(INVALID_FLOAT), w(INVALID_FLOAT) {}
+    float4(float _x, float _y, float _z, float _w) : x(_x), y(_y), z(_z), w(_w) {}
+    float x, y, z, w;
+};
+
+struct float4x4
+{
+    //! All access points take row index as a parameter
+    inline float4& operator[](uint32_t i) { return row[i]; }
+    inline const float4& operator[](uint32_t i) const { return row[i]; }
+    inline void setRow(uint32_t i, const float4& v) { row[i] = v; }
+    inline const float4& getRow(uint32_t i) { return row[i]; }
+
+    //! Row major matrix
+    float4 row[4];
+};
+
+struct Extent
+{
+    uint32_t top{};
+    uint32_t left{};
+    uint32_t width{};
+    uint32_t height{};
+
+    inline operator bool() const { return width != 0 && height != 0; }
+    inline bool operator==(const Extent& rhs) const 
+    { 
+        return top == rhs.top && left == rhs.left &&
+        width == rhs.width && height == rhs.height;
+    }
+    inline bool operator!=(const Extent& rhs) const
+    {
+        return !operator==(rhs);
+    }
+    inline bool isSameRes(const Extent& rhs) const
+    {
+        return width == rhs.width && height == rhs.height;
+    }
+
+#if defined(_WINDEF_)
+    // Cast helper for sl::Extent->RECT when windef.h has been included
+    inline operator RECT() const { return RECT { (LONG)left, (LONG)top, (LONG)(left + width), (LONG)(top + height) }; }
+#endif
+};
+
+//! For cases when value has to be provided and we don't have good default
+enum Boolean : char
+{
+    eFalse,
+    eTrue,
+    eInvalid
+};
+
+//! Common constants, all parameters must be provided unless they are marked as optional
+//! 
+//! {DCD35AD7-4E4A-4BAD-A90C-E0C49EB23AFE}
+SL_STRUCT(Constants, StructType({ 0xdcd35ad7, 0x4e4a, 0x4bad, { 0xa9, 0xc, 0xe0, 0xc4, 0x9e, 0xb2, 0x3a, 0xfe } }), kStructVersion2)
+    //! IMPORTANT: All matrices are row major (see float4x4 definition) and
+    //! must NOT contain temporal AA jitter offset (if any). Any jitter offset
+    //! should be provided as the additional parameter Constants::jitterOffset (see below)
+            
+    //! Specifies matrix transformation from the camera view to the clip space.
+    float4x4 cameraViewToClip;
+    //! Specifies matrix transformation from the clip space to the camera view space.
+    float4x4 clipToCameraView;
+    //! Optional - Specifies matrix transformation describing lens distortion in clip space.
+    float4x4 clipToLensClip;
+    //! Specifies matrix transformation from the current clip to the previous clip space.
+    //! clipToPrevClip = clipToView * viewToViewPrev * viewToClipPrev
+    //! Sample code can be found in sl_matrix_helpers.h
+    float4x4 clipToPrevClip;
+    //! Specifies matrix transformation from the previous clip to the current clip space.
+    //! prevClipToClip = clipToPrevClip.inverse()
+    float4x4 prevClipToClip;
+        
+    //! Specifies pixel space jitter offset
+    float2 jitterOffset;
+    //! Specifies scale factors used to normalize motion vectors (so the values are in [-1,1] range)
+    float2 mvecScale;
+    //! Optional - Specifies camera pinhole offset if used.
+    float2 cameraPinholeOffset;
+    //! Specifies camera position in world space.
+    float3 cameraPos;
+    //! Specifies camera up vector in world space.
+    float3 cameraUp;
+    //! Specifies camera right vector in world space.
+    float3 cameraRight;
+    //! Specifies camera forward vector in world space.
+    float3 cameraFwd;
+        
+    //! Specifies camera near view plane distance.
+    float cameraNear = INVALID_FLOAT;
+    //! Specifies camera far view plane distance.
+    float cameraFar = INVALID_FLOAT;
+    //! Specifies camera field of view in radians.
+    float cameraFOV = INVALID_FLOAT;
+    //! Specifies camera aspect ratio defined as view space width divided by height.
+    float cameraAspectRatio = INVALID_FLOAT;
+    //! Specifies which value represents an invalid (un-initialized) value in the motion vectors buffer
+    //! NOTE: This is only required if `cameraMotionIncluded` is set to false and SL needs to compute it.
+    float motionVectorsInvalidValue = INVALID_FLOAT;
+
+    //! Specifies if depth values are inverted (value closer to the camera is higher) or not.
+    Boolean depthInverted = Boolean::eInvalid;
+    //! Specifies if camera motion is included in the MVec buffer.
+    Boolean cameraMotionIncluded = Boolean::eInvalid;
+    //! Specifies if motion vectors are 3D or not.
+    Boolean motionVectors3D = Boolean::eInvalid;
+    //! Specifies if previous frame has no connection to the current one (i.e. motion vectors are invalid)
+    Boolean reset = Boolean::eInvalid;
+    //! Specifies if orthographic projection is used or not.
+    Boolean orthographicProjection = Boolean::eFalse;
+    //! Specifies if motion vectors are already dilated or not.
+    Boolean motionVectorsDilated = Boolean::eFalse;
+    //! Specifies if motion vectors are jittered or not.
+    Boolean motionVectorsJittered = Boolean::eFalse;
+
+    //! Version 2 members:
+    //! 
+    //! Optional heuristic that specifies the minimum depth difference between two objects in screen-space.
+    //! The units of the value are in linear depth units.
+    //! Linear depth is computed as:
+    //!     if depthInverted is false:  `lin_depth = 1 / (1 - depth)` 
+    //!     if depthInverted is true:   `lin_depth = 1 / depth`
+    //! 
+    //! Although unlikely to need to be modified, smaller thresholds are useful when depth units are
+    //! unusually compressed into a small dynamic range near 1.
+    //! 
+    //! If not specified, the default value is 40.0f.
+    float minRelativeLinearDepthObjectSeparation = 40.0f;
+
+    //! IMPORTANT: New members go here or if optional can be chained in a new struct, see sl_struct.h for details
+};
+
+}

--- a/external/streamline/sl_result.h
+++ b/external/streamline/sl_result.h
@@ -1,0 +1,72 @@
+/*
+* Copyright (c) 2022-2023 NVIDIA CORPORATION. All rights reserved
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/ 
+
+#pragma once
+
+namespace sl
+{
+
+enum class Result
+{
+    eOk,
+    eErrorIO,
+    eErrorDriverOutOfDate,
+    eErrorOSOutOfDate,
+    eErrorOSDisabledHWS,
+    eErrorDeviceNotCreated,
+    eErrorNoSupportedAdapterFound,
+    eErrorAdapterNotSupported,
+    eErrorNoPlugins,
+    eErrorVulkanAPI,
+    eErrorDXGIAPI,
+    eErrorD3DAPI,
+    eErrorNRDAPI,
+    eErrorNVAPI,
+    eErrorReflexAPI,
+    eErrorNGXFailed,
+    eErrorJSONParsing,
+    eErrorMissingProxy,
+    eErrorMissingResourceState,
+    eErrorInvalidIntegration,
+    eErrorMissingInputParameter,
+    eErrorNotInitialized,
+    eErrorComputeFailed,
+    eErrorInitNotCalled,
+    eErrorExceptionHandler,
+    eErrorInvalidParameter,
+    eErrorMissingConstants,
+    eErrorDuplicatedConstants,
+    eErrorMissingOrInvalidAPI,
+    eErrorCommonConstantsMissing,
+    eErrorUnsupportedInterface,
+    eErrorFeatureMissing,
+    eErrorFeatureNotSupported,
+    eErrorFeatureMissingHooks,
+    eErrorFeatureFailedToLoad,
+    eErrorFeatureWrongPriority,
+    eErrorFeatureMissingDependency,
+    eErrorFeatureManagerInvalidState,
+    eErrorInvalidState,
+    eWarnOutOfVRAM
+};
+
+}

--- a/external/streamline/sl_struct.h
+++ b/external/streamline/sl_struct.h
@@ -1,0 +1,131 @@
+/*
+* Copyright (c) 2022-2023 NVIDIA CORPORATION. All rights reserved
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/ 
+
+#pragma once
+
+#include <stdint.h>
+#include <string.h>
+
+namespace sl
+{
+
+//! GUID
+struct StructType
+{
+    uint32_t data1;
+    uint16_t data2;
+    uint16_t data3;
+    uint8_t  data4[8];
+
+    inline bool operator==(const StructType& rhs) const { return memcmp(this, &rhs, sizeof(*this)) == 0; }
+    inline bool operator!=(const StructType& rhs) const { return memcmp(this, &rhs, sizeof(*this)) != 0; }
+};
+
+//! SL is using typed and versioned structures which can be chained or not.
+//! 
+//! --- OPTION 1 ---
+//! 
+//! New members must be added at the end and version needs to be increased:
+//! 
+//! SL_STRUCT(S1, GUID1, kStructVersion1)
+//! {
+//!     A
+//!     B
+//!     C
+//! }
+//! 
+//! SL_STRUCT(S1, GUID1, kStructVersion2) // Note that version is bumped
+//! {
+//!     // V1
+//!     A
+//!     B
+//!     C
+//! 
+//!     //! V2 - new members always go at the end!
+//!     D
+//!     E
+//! }
+//! 
+//! Here is one example on how to check for version and handle backwards compatibility:
+//! 
+//! void func(const S1* input)
+//! {
+//!     // Access A, B, C as needed
+//!     ...
+//!     if (input->structVersion >= kStructVersion2)
+//!     {
+//!         // Safe to access D, E
+//!     }
+//! }
+
+
+//! --- OPTION 2 ---
+//! 
+//! New members are optional and added to a new struct which is then chained as needed:
+//! 
+//! SL_STRUCT(S1, GUID1, kStructVersion1)
+//! {
+//!     A
+//!     B
+//!     C
+//! }
+//! 
+//! SL_STRUCT(S2, GUID2, kStructVersion1) // Note that this is a different struct with new GUID
+//! {
+//!     D
+//!     E
+//! }
+//! 
+//! S1 s1;
+//! S2 s2
+//! s1.next = &s2; // optional parameters in S2
+
+//! IMPORTANT: New members in the structure always go at the end!
+//!
+constexpr uint32_t kStructVersion1 = 1;
+constexpr uint32_t kStructVersion2 = 2;
+constexpr uint32_t kStructVersion3 = 3;
+
+struct BaseStructure
+{
+    BaseStructure() = delete;
+    BaseStructure(StructType t, uint32_t v) : structType(t), structVersion(v) {};
+    BaseStructure* next{};
+    StructType structType{};
+    size_t structVersion;
+};
+
+#define SL_STRUCT(name, guid, version)                                      \
+struct name : public BaseStructure                                          \
+{                                                                           \
+    name() : BaseStructure(guid, version){}                                 \
+    constexpr static StructType s_structType = guid;                        \
+
+#define SL_STRUCT_PROTECTED(name, guid, version)                            \
+struct name : public BaseStructure                                          \
+{                                                                           \
+protected:                                                                  \
+    name() : BaseStructure(guid, version){}                                 \
+public:                                                                     \
+    constexpr static StructType s_structType = guid;                        \
+
+} // namespace sl

--- a/external/streamline/sl_version.h
+++ b/external/streamline/sl_version.h
@@ -1,0 +1,98 @@
+/*
+* Copyright (c) 2022-2023 NVIDIA CORPORATION. All rights reserved
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#pragma once
+
+#define SL_VERSION_MAJOR 2
+#define SL_VERSION_MINOR 4
+#define SL_VERSION_PATCH 15
+
+#include <string>
+
+namespace sl
+{
+constexpr uint64_t kSDKVersionMagic = 0xfedc;
+constexpr uint64_t kSDKVersion = (uint64_t(SL_VERSION_MAJOR) << 48) | (uint64_t(SL_VERSION_MINOR) << 32) | (uint64_t(SL_VERSION_PATCH) << 16) | kSDKVersionMagic;
+
+struct Version
+{
+    Version() : major(0), minor(0), build(0) {};
+    Version(uint32_t v1, uint32_t v2, uint32_t v3) : major(v1), minor(v2), build(v3) {};
+
+    inline operator bool() const { return major != 0 || minor != 0 || build != 0; }
+
+    inline std::string toStr() const
+    {
+        return std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(build);
+    }
+    inline std::wstring toWStr() const
+    {
+        return std::to_wstring(major) + L"." + std::to_wstring(minor) + L"." + std::to_wstring(build);
+    }
+    inline std::wstring toWStrOTAId() const
+    {
+        return std::to_wstring((major << 16) | (minor << 8) | build);
+    }
+    inline bool operator==(const Version& rhs) const
+    {
+        return major == rhs.major && minor == rhs.minor && build == rhs.build;
+    }
+    inline bool operator>(const Version& rhs) const
+    {
+        if (major < rhs.major) return false;
+        else if (major > rhs.major) return true;
+        // major version the same
+        if (minor < rhs.minor) return false;
+        else if (minor > rhs.minor) return true;
+        // minor version the same
+        if (build < rhs.build) return false;
+        else if (build > rhs.build) return true;
+        // build version the same
+        return false;
+    };
+    inline bool operator>=(const Version& rhs) const
+    {
+        return operator>(rhs) || operator==(rhs);
+    };
+    inline bool operator<(const Version& rhs) const
+    {
+        if (major > rhs.major) return false;
+        else if (major < rhs.major) return true;
+        // major version the same
+        if (minor > rhs.minor) return false;
+        else if (minor < rhs.minor) return true;
+        // minor version the same
+        if (build > rhs.build) return false;
+        else if (build < rhs.build) return true;
+        // build version the same
+        return false;
+    };
+    inline bool operator<=(const Version& rhs) const
+    {
+        return operator<(rhs) || operator==(rhs);
+    };
+
+    uint32_t major;
+    uint32_t minor;
+    uint32_t build;
+};
+
+}

--- a/nvngx.ini
+++ b/nvngx.ini
@@ -265,6 +265,22 @@ RenderPresetUltraPerformance=auto
 
 
 
+; -------------------------------------------------------
+[DLSSG]
+; -------------------------------------------------------
+; You need to provide dlssg_to_fsr3_amd_is_better.dll from Nukem's dlssg-to-fsr3 mod
+; AMD/Intel GPU users need to add fakenvapi as well
+; Force disables Opti's FG (no 4x FG for now)
+; true or false - Default (auto) is false
+DLSSGMod=auto
+
+; Enables spoofing of hardware accelerated gpu scheduling
+; Required for nukem's mod, let's RTX40xx series users use DLSSG without HAGS enabled 
+; true or false - Default (auto) is false, unless DLSSG mod is enabled
+SpoofHAGS=auto
+
+
+
 
 ; -------------------------------------------------------
 [Menu]


### PR DESCRIPTION
Let's the user select DLSSG from the game settings and is mutually exclusive with Opti's own FG. The idea is very simple, just pass ngx calls that refer to FG to dlssg-to-fsr3.

Has all the required spoofing. Includes a workaround for Cyberpunk's bug causing glitched visuals on RDNA2 on Windows courtesy of Nukem as well as a depth copy that fixes many non-UE games on AMD on Windows. Also adds logging of streamline messages which might come handy.

dlssg_to_fsr3_amd_is_better.dll needs to be provided by the user.