### PR TITLE
Dynamic font creation

### DIFF
--- a/OptiScaler/OptiScaler.vcxproj.filters
+++ b/OptiScaler/OptiScaler.vcxproj.filters
@@ -374,6 +374,9 @@
     <ClInclude Include="shaders\depth_scale\precompiled\DS_Shader_Dx11.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="menu\menu_base.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Config.cpp">
@@ -594,6 +597,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="shaders\depth_scale\DS_Dx12.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="menu\menu_base.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/OptiScaler/include/imgui/imgui.h
+++ b/OptiScaler/include/imgui/imgui.h
@@ -193,6 +193,8 @@ struct ImGuiTableColumnSortSpecs;   // Sorting specification for one column of a
 struct ImGuiTextBuffer;             // Helper to hold and append into a text buffer (~string builder)
 struct ImGuiTextFilter;             // Helper to parse and apply text filters (e.g. "aaaaa[,bbbbb][,ccccc]")
 struct ImGuiViewport;               // A Platform Window (always only one in 'master' branch), in the future may represent Platform Monitor
+struct ImTexture;
+struct ImTextureUpdateData;
 
 // Enumerations
 // - We don't use strongly typed enums much because they add constraints (can't extend in private code, can't store typed in bit fields, extra casting on iteration)
@@ -333,6 +335,7 @@ namespace ImGui
     IMGUI_API void          EndFrame();                                 // ends the Dear ImGui frame. automatically called by Render(). If you don't need to render data (skipping rendering) you may call EndFrame() without Render()... but you'll have wasted CPU already! If you don't need to render, better to not create any windows and not call NewFrame() at all!
     IMGUI_API void          Render();                                   // ends the Dear ImGui frame, finalize the draw data. You can then get call GetDrawData().
     IMGUI_API ImDrawData*   GetDrawData();                              // valid after Render() and until the next call to NewFrame(). this is what you have to render.
+    IMGUI_API ImTextureUpdateData* GetTextureUpdateData();
 
     // Demo, Debug, Information
     IMGUI_API void          ShowDemoWindow(bool* p_open = NULL);        // create Demo window. demonstrate most ImGui features. call this to learn about the library! try to make it always available in your application!
@@ -345,6 +348,8 @@ namespace ImGui
     IMGUI_API void          ShowFontSelector(const char* label);        // add font selector block (not a window), essentially a combo listing the loaded fonts.
     IMGUI_API void          ShowUserGuide();                            // add basic help/info block (not a window): how to manipulate ImGui as an end-user (mouse/keyboard controls).
     IMGUI_API const char*   GetVersion();                               // get the compiled version string e.g. "1.80 WIP" (essentially the value for IMGUI_VERSION from the compiled version of imgui.cpp)
+
+    IMGUI_API void          ShowFontDemoWindow();
 
     // Styles
     IMGUI_API void          StyleColorsDark(ImGuiStyle* dst = NULL);    // new, recommended style (default)
@@ -561,7 +566,9 @@ namespace ImGui
     // - Read about ImTextureID here: https://github.com/ocornut/imgui/wiki/Image-Loading-and-Displaying-Examples
     // - 'uv0' and 'uv1' are texture coordinates. Read about them from the same link above.
     // - Note that Image() may add +2.0f to provided size if a border is visible, ImageButton() adds style.FramePadding*2.0f to provided size.
+    IMGUI_API void          Image(ImTexture texture, const ImVec2& image_size, const ImVec2& uv0 = ImVec2(0, 0), const ImVec2& uv1 = ImVec2(1, 1), const ImVec4& tint_col = ImVec4(1, 1, 1, 1), const ImVec4& border_col = ImVec4(0, 0, 0, 0));
     IMGUI_API void          Image(ImTextureID user_texture_id, const ImVec2& image_size, const ImVec2& uv0 = ImVec2(0, 0), const ImVec2& uv1 = ImVec2(1, 1), const ImVec4& tint_col = ImVec4(1, 1, 1, 1), const ImVec4& border_col = ImVec4(0, 0, 0, 0));
+    IMGUI_API bool          ImageButton(const char* str_id, ImTexture texture, const ImVec2& image_size, const ImVec2& uv0 = ImVec2(0, 0), const ImVec2& uv1 = ImVec2(1, 1), const ImVec4& bg_col = ImVec4(0, 0, 0, 0), const ImVec4& tint_col = ImVec4(1, 1, 1, 1));
     IMGUI_API bool          ImageButton(const char* str_id, ImTextureID user_texture_id, const ImVec2& image_size, const ImVec2& uv0 = ImVec2(0, 0), const ImVec2& uv1 = ImVec2(1, 1), const ImVec4& bg_col = ImVec4(0, 0, 0, 0), const ImVec4& tint_col = ImVec4(1, 1, 1, 1));
 
     // Widgets: Combo Box (Dropdown)
@@ -1614,6 +1621,7 @@ enum ImGuiBackendFlags_
     ImGuiBackendFlags_HasMouseCursors       = 1 << 1,   // Backend Platform supports honoring GetMouseCursor() value to change the OS cursor shape.
     ImGuiBackendFlags_HasSetMousePos        = 1 << 2,   // Backend Platform supports io.WantSetMousePos requests to reposition the OS mouse position (only used if ImGuiConfigFlags_NavEnableSetMousePos is set).
     ImGuiBackendFlags_RendererHasVtxOffset  = 1 << 3,   // Backend Renderer supports ImDrawCmd::VtxOffset. This enables output of large meshes (64K+ vertices) while still using 16-bit indices.
+    ImGuiBackendFlags_RendererHasTexReload  = 1 << 4    // Backend Renderer checks IsDirty() on the font atlas texture after EndFrame()/Render() and reupload the texture to GPU if required.
 };
 
 // Enumeration for PushStyleColor() / PopStyleColor()
@@ -2924,10 +2932,41 @@ typedef void (*ImDrawCallback)(const ImDrawList* parent_list, const ImDrawCmd* c
 //   this fields allow us to render meshes larger than 64K vertices while keeping 16-bit indices.
 //   Backends made for <1.71. will typically ignore the VtxOffset fields.
 // - The ClipRect/TextureId/VtxOffset fields must be contiguous as we memcmp() them together (this is asserted for).
+typedef unsigned short ImTextureType;
+
+enum ImTextureType_
+{
+    ImTextureType_Atlas,
+    ImTextureType_UserID
+};
+
+struct ImTexture
+{
+    union
+    {
+        ImTextureID     TextureId;
+        ImFontAtlas*    FontAtlas;
+    };
+    ImTextureType       Type;
+    unsigned short      FontAtlasPage;
+
+    // FIXME-TEXUPDATE: Explain why explicit
+    ImTexture() {}
+    explicit ImTexture(ImFontAtlas* font_atlas);
+    explicit ImTexture(ImTextureID texture_id);
+
+    // memcpy() compare also padding bytes on x64 archs which lead to incorrect compareison result
+    // inline friend bool operator==(const ImTexture& lhs, const ImTexture& rhs) { return memcmp(&lhs, &rhs, sizeof(ImTexture)) == 0; }
+    inline friend bool operator==(const ImTexture& lhs, const ImTexture& rhs) { return lhs.TextureId == rhs.TextureId && lhs.Type == rhs.Type && lhs.FontAtlasPage == rhs.FontAtlasPage; }
+    inline friend bool operator!=(const ImTexture& lhs, const ImTexture& rhs) { return !(lhs == rhs); }
+
+    inline ImTextureID GetID() const;
+};
+
 struct ImDrawCmd
 {
     ImVec4          ClipRect;           // 4*4  // Clipping rectangle (x1, y1, x2, y2). Subtract ImDrawData->DisplayPos to get clipping rectangle in "viewport" coordinates
-    ImTextureID     TextureId;          // 4-8  // User-provided texture ID. Set by user in ImfontAtlas::SetTexID() for fonts or passed to Image*() functions. Ignore if never using images or multiple fonts atlas.
+    ImTexture       Texture;            // 8-12 // User-provided texture ID. Set by user in ImfontAtlas::SetTexID() for fonts or passed to Image*() functions. Ignore if never using images or multiple fonts atlas.
     unsigned int    VtxOffset;          // 4    // Start offset in vertex buffer. ImGuiBackendFlags_RendererHasVtxOffset: always 0, otherwise may be >0 to support meshes larger than 64K vertices with 16-bit indices.
     unsigned int    IdxOffset;          // 4    // Start offset in index buffer.
     unsigned int    ElemCount;          // 4    // Number of indices (multiple of 3) to be rendered as triangles. Vertices are stored in the callee ImDrawList's vtx_buffer[] array, indices in idx_buffer[].
@@ -2936,8 +2975,9 @@ struct ImDrawCmd
 
     ImDrawCmd() { memset(this, 0, sizeof(*this)); } // Also ensure our padding fields are zeroed
 
+    inline void SetTexID(ImTextureID tex_id) { Texture.TextureId = tex_id; Texture.Type = ImTextureType_UserID; }
     // Since 1.83: returns ImTextureID associated with this draw call. Warning: DO NOT assume this is always same as 'TextureId' (we will change this function for an upcoming feature)
-    inline ImTextureID GetTexID() const { return TextureId; }
+    inline ImTextureID GetTexID() const { return Texture.GetID(); }
 };
 
 // Vertex layout
@@ -2960,7 +3000,7 @@ IMGUI_OVERRIDE_DRAWVERT_STRUCT_LAYOUT;
 struct ImDrawCmdHeader
 {
     ImVec4          ClipRect;
-    ImTextureID     TextureId;
+    ImTexture       Texture;
     unsigned int    VtxOffset;
 };
 
@@ -3046,7 +3086,7 @@ struct ImDrawList
     ImDrawCmdHeader         _CmdHeader;         // [Internal] template of active commands. Fields should match those of CmdBuffer.back().
     ImDrawListSplitter      _Splitter;          // [Internal] for channels api (note: prefer using your own persistent instance of ImDrawListSplitter!)
     ImVector<ImVec4>        _ClipRectStack;     // [Internal]
-    ImVector<ImTextureID>   _TextureIdStack;    // [Internal]
+    ImVector<ImTexture>     _TextureStack;      // [Internal]
     float                   _FringeScale;       // [Internal] anti-alias fringe is scaled by this value, this helps to keep things sharp while zooming at vertex buffer content
     const char*             _OwnerName;         // Pointer to owner window's name for debugging
 
@@ -3057,8 +3097,10 @@ struct ImDrawList
     IMGUI_API void  PushClipRect(const ImVec2& clip_rect_min, const ImVec2& clip_rect_max, bool intersect_with_current_clip_rect = false);  // Render-level scissoring. This is passed down to your render function but not used for CPU-side coarse clipping. Prefer using higher-level ImGui::PushClipRect() to affect logic (hit-testing and widget culling)
     IMGUI_API void  PushClipRectFullScreen();
     IMGUI_API void  PopClipRect();
-    IMGUI_API void  PushTextureID(ImTextureID texture_id);
-    IMGUI_API void  PopTextureID();
+    IMGUI_API void  PushTexture(ImTexture texture);
+    IMGUI_API void  PopTexture();
+    IMGUI_API void  PushTextureID(ImTextureID texture_id);  // DEPRECATED???
+    IMGUI_API void  PopTextureID();                         // DEPRECATED???
     inline ImVec2   GetClipRectMin() const { const ImVec4& cr = _ClipRectStack.back(); return ImVec2(cr.x, cr.y); }
     inline ImVec2   GetClipRectMax() const { const ImVec4& cr = _ClipRectStack.back(); return ImVec2(cr.z, cr.w); }
 
@@ -3099,8 +3141,11 @@ struct ImDrawList
     // - Read FAQ to understand what ImTextureID is.
     // - "p_min" and "p_max" represent the upper-left and lower-right corners of the rectangle.
     // - "uv_min" and "uv_max" represent the normalized texture coordinates to use for those corners. Using (0,0)->(1,1) texture coordinates will generally display the entire texture.
+    IMGUI_API void  AddImage(ImTexture texture, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min = ImVec2(0, 0), const ImVec2& uv_max = ImVec2(1, 1), ImU32 col = IM_COL32_WHITE);
     IMGUI_API void  AddImage(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min = ImVec2(0, 0), const ImVec2& uv_max = ImVec2(1, 1), ImU32 col = IM_COL32_WHITE);
+    IMGUI_API void  AddImageQuad(ImTexture texture, const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& uv1 = ImVec2(0, 0), const ImVec2& uv2 = ImVec2(1, 0), const ImVec2& uv3 = ImVec2(1, 1), const ImVec2& uv4 = ImVec2(0, 1), ImU32 col = IM_COL32_WHITE);
     IMGUI_API void  AddImageQuad(ImTextureID user_texture_id, const ImVec2& p1, const ImVec2& p2, const ImVec2& p3, const ImVec2& p4, const ImVec2& uv1 = ImVec2(0, 0), const ImVec2& uv2 = ImVec2(1, 0), const ImVec2& uv3 = ImVec2(1, 1), const ImVec2& uv4 = ImVec2(0, 1), ImU32 col = IM_COL32_WHITE);
+    IMGUI_API void  AddImageRounded(ImTexture texture, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min, const ImVec2& uv_max, ImU32 col, float rounding, ImDrawFlags flags = 0);
     IMGUI_API void  AddImageRounded(ImTextureID user_texture_id, const ImVec2& p_min, const ImVec2& p_max, const ImVec2& uv_min, const ImVec2& uv_max, ImU32 col, float rounding, ImDrawFlags flags = 0);
 
     // Stateful path API, add points then finish with PathFillConvex() or PathStroke()
@@ -3159,9 +3204,9 @@ struct ImDrawList
     IMGUI_API void  _PopUnusedDrawCmd();
     IMGUI_API void  _TryMergeDrawCmds();
     IMGUI_API void  _OnChangedClipRect();
-    IMGUI_API void  _OnChangedTextureID();
+    IMGUI_API void  _OnChangedTexture();
     IMGUI_API void  _OnChangedVtxOffset();
-    IMGUI_API void  _SetTextureID(ImTextureID texture_id);
+    IMGUI_API void  _SetTexture(ImTexture texture);
     IMGUI_API int   _CalcCircleAutoSegmentCount(float radius) const;
     IMGUI_API void  _PathArcToFastEx(const ImVec2& center, float radius, int a_min_sample, int a_max_sample, int a_step);
     IMGUI_API void  _PathArcToN(const ImVec2& center, float radius, float a_min, float a_max, int num_segments);
@@ -3289,6 +3334,43 @@ enum ImFontAtlasFlags_
 //   You can set font_cfg->FontDataOwnedByAtlas=false to keep ownership of your data and it won't be freed,
 // - Even though many functions are suffixed with "TTF", OTF data is supported just as well.
 // - This is an old API and it is currently awkward for those and various other reasons! We will address them in the future!
+typedef unsigned int ImTextureFormat;
+
+enum ImTextureFormat_
+{
+    ImTextureFormat_Alpha8, // 1 component per pixel, each component is unsigned 8-bit. Total size = TexWidth * TexHeight
+    ImTextureFormat_RGBA32  // 4 component per pixel, each component is unsigned 8-bit. Total size = TexWidth * TexHeight * 4
+};
+
+struct ImTextureData
+{
+    IMGUI_API ImTextureData();
+    IMGUI_API ~ImTextureData();
+    IMGUI_API void              Reset();
+    IMGUI_API void              AllocatePixels(int width, int height, ImTextureFormat format, bool clear = true);
+    IMGUI_API void              DiscardPixels();
+    IMGUI_API void              EnsureFormat(ImTextureFormat format);
+
+    void                        SetTexID(ImTextureID tex_id) { TexID = tex_id; }
+    ImTextureID                 GetTexID() const { return TexID; }
+
+    void                        MarkDirty() { TexDirty = true; }
+    void                        MarkClean() { TexDirty = false; }
+    bool                        IsDirty() const { return TexDirty; }
+
+    ImTextureID                 TexID;
+    ImTextureFormat             TexFormat;
+    void*                       TexPixels;
+    int                         TexWidth;
+    int                         TexHeight;
+    bool                        TexDirty;
+};
+
+struct ImTextureUpdateData
+{
+    ImVector<ImTextureData*>    Textures;
+};
+
 struct ImFontAtlas
 {
     IMGUI_API ImFontAtlas();
@@ -3310,10 +3392,13 @@ struct ImFontAtlas
     // Building in RGBA32 format is provided for convenience and compatibility, but note that unless you manually manipulate or copy color data into
     // the texture (e.g. when using the AddCustomRect*** api), then the RGB pixels emitted will always be white (~75% of memory/bandwidth waste.
     IMGUI_API bool              Build();                    // Build pixels data. This is called automatically for you by the GetTexData*** functions.
+    IMGUI_API bool              IsDirty();                  // Returns true if the font needs to be (re-)built. User code should call GetTexData*** and update either the whole texture or dirty region as required.
     IMGUI_API void              GetTexDataAsAlpha8(unsigned char** out_pixels, int* out_width, int* out_height, int* out_bytes_per_pixel = NULL);  // 1 byte per-pixel
     IMGUI_API void              GetTexDataAsRGBA32(unsigned char** out_pixels, int* out_width, int* out_height, int* out_bytes_per_pixel = NULL);  // 4 bytes-per-pixel
-    bool                        IsBuilt() const             { return Fonts.Size > 0 && TexReady; } // Bit ambiguous: used to detect when user didn't build texture but effectively we should check TexID != 0 except that would be backend dependent...
-    void                        SetTexID(ImTextureID id)    { TexID = id; }
+    IMGUI_API ImTextureUpdateData* GetTextureUpdateData();
+    bool                        IsBuilt() const             { return Fonts.Size > 0 && TexReady; } // Bit ambiguous: used to detect when user didn't built texture but effectively we should check TexID != 0 except that would be backend dependent...
+    void                        SetTexID(ImTextureID id)    { TexData.TexID = id; }
+    ImTextureID                 GetTexID() const            { return TexData.TexID; }
 
     //-------------------------------------------
     // Glyph Ranges
@@ -3351,13 +3436,16 @@ struct ImFontAtlas
     // [Internal]
     IMGUI_API void              CalcCustomRectUV(const ImFontAtlasCustomRect* rect, ImVec2* out_uv_min, ImVec2* out_uv_max) const;
     IMGUI_API bool              GetMouseCursorTexData(ImGuiMouseCursor cursor, ImVec2* out_offset, ImVec2* out_size, ImVec2 out_uv_border[2], ImVec2 out_uv_fill[2]);
+    IMGUI_API void              MarkDirty(); // Mark atlas texture as dirty
+    IMGUI_API void              MarkClean(); // Mark the whole texture as clean. Should be called after uploading texture.
+    IMGUI_API void              PushTexPage();
+    IMGUI_API void              ClearTransientTextures();
 
     //-------------------------------------------
     // Members
     //-------------------------------------------
 
     ImFontAtlasFlags            Flags;              // Build flags (see ImFontAtlasFlags_)
-    ImTextureID                 TexID;              // User data to refer to the texture once it has been uploaded to user's graphic systems. It is passed back to you during rendering via the ImDrawCmd structure.
     int                         TexDesiredWidth;    // Texture width desired by user before Build(). Must be a power-of-two. If have many glyphs your graphics API have texture size restrictions you may want to increase texture width to decrease height.
     int                         TexGlyphPadding;    // Padding between glyphs within texture in pixels. Defaults to 1. If your rendering method doesn't rely on bilinear filtering you may set this to 0 (will also need to set AntiAliasedLinesUseTex = false).
     bool                        Locked;             // Marked as Locked by ImGui::NewFrame() so attempt to modify the atlas will assert.
@@ -3366,17 +3454,16 @@ struct ImFontAtlas
     // [Internal]
     // NB: Access texture data via GetTexData*() calls! Which will setup a default font for you.
     bool                        TexReady;           // Set when texture was built matching current font input
-    bool                        TexPixelsUseColors; // Tell whether our texture data is known to use colors (rather than just alpha channel), in order to help backend select a format.
-    unsigned char*              TexPixelsAlpha8;    // 1 component per pixel, each component is unsigned 8-bit. Total size = TexWidth * TexHeight
-    unsigned int*               TexPixelsRGBA32;    // 4 component per pixel, each component is unsigned 8-bit. Total size = TexWidth * TexHeight * 4
-    int                         TexWidth;           // Texture width calculated during Build().
-    int                         TexHeight;          // Texture height calculated during Build().
+    bool                        TexDirty;           // Indicate that content of the atlas texture has changed and need to be uploaded again by backend
+    ImTextureData               TexData;
     ImVec2                      TexUvScale;         // = (1.0f/TexWidth, 1.0f/TexHeight)
     ImVec2                      TexUvWhitePixel;    // Texture coordinates to a white pixel
     ImVector<ImFont*>           Fonts;              // Hold all the fonts returned by AddFont*. Fonts[0] is the default font upon calling ImGui::NewFrame(), use ImGui::PushFont()/PopFont() to change the current font.
     ImVector<ImFontAtlasCustomRect> CustomRects;    // Rectangles for packing custom texture data into the atlas.
     ImVector<ImFontConfig>      ConfigData;         // Configuration data
     ImVec4                      TexUvLines[IM_DRAWLIST_TEX_LINES_WIDTH_MAX + 1];  // UVs for baked anti-aliased lines
+    ImVector<ImTextureData>     TexPages;
+    ImTextureUpdateData         TexUpdateData;      // Only access via GetTextureUpdateData()
 
     // [Internal] Font builder
     const ImFontBuilderIO*      FontBuilderIO;      // Opaque interface to a font builder (default to stb_truetype, can be changed to use FreeType by defining IMGUI_ENABLE_FREETYPE).
@@ -3485,6 +3572,39 @@ struct ImGuiViewport
     ImVec2              GetCenter() const       { return ImVec2(Pos.x + Size.x * 0.5f, Pos.y + Size.y * 0.5f); }
     ImVec2              GetWorkCenter() const   { return ImVec2(WorkPos.x + WorkSize.x * 0.5f, WorkPos.y + WorkSize.y * 0.5f); }
 };
+
+
+//-----------------------------------------------------------------------------
+// [SECTION] Inline function implementations
+//-----------------------------------------------------------------------------
+
+// Declared here instead of in ImTexture because we need knowledge of ImFontAtlas
+inline ImTexture::ImTexture(ImFontAtlas* font_atlas)
+{
+    FontAtlas = font_atlas;
+    Type = ImTextureType_Atlas;
+    FontAtlasPage = (unsigned short)font_atlas->TexPages.Size; // FIXME-TEXUPDATE: Current?
+}
+
+inline ImTexture::ImTexture(ImTextureID texture_id)
+{
+    TextureId = texture_id;
+    Type = ImTextureType_UserID;
+    FontAtlasPage = 0;
+}
+
+inline ImTextureID ImTexture::GetID() const
+{
+    if (Type == ImTextureType_Atlas)
+    {
+        if (FontAtlasPage < FontAtlas->TexPages.Size)
+            return FontAtlas->TexPages[FontAtlasPage].GetTexID();
+        else
+            return FontAtlas->TexData.GetTexID();
+    }
+    else
+        return TextureId;
+}
 
 //-----------------------------------------------------------------------------
 // [SECTION] Platform Dependent Interfaces

--- a/OptiScaler/include/imgui/imgui_demo.cpp
+++ b/OptiScaler/include/imgui/imgui_demo.cpp
@@ -385,6 +385,8 @@ void ImGui::ShowDemoWindow(bool* p_open)
     // Verify ABI compatibility between caller code and compiled version of Dear ImGui. This helps detects some build issues.
     IMGUI_CHECKVERSION();
 
+    ShowFontDemoWindow();
+
     // Stored data
     static ImGuiDemoWindowData demo_data;
 
@@ -576,6 +578,7 @@ void ImGui::ShowDemoWindow(bool* p_open)
             ImGui::CheckboxFlags("io.BackendFlags: HasMouseCursors",      &io.BackendFlags, ImGuiBackendFlags_HasMouseCursors);
             ImGui::CheckboxFlags("io.BackendFlags: HasSetMousePos",       &io.BackendFlags, ImGuiBackendFlags_HasSetMousePos);
             ImGui::CheckboxFlags("io.BackendFlags: RendererHasVtxOffset", &io.BackendFlags, ImGuiBackendFlags_RendererHasVtxOffset);
+            ImGui::CheckboxFlags("io.BackendFlags: RendererHasTexReload", &io.BackendFlags, ImGuiBackendFlags_RendererHasTexReload);
             ImGui::EndDisabled();
             ImGui::TreePop();
             ImGui::Spacing();
@@ -1286,9 +1289,9 @@ static void ShowDemoWindowWidgets(ImGuiDemoWindowData* demo_data)
         // - Consider using the lower-level ImDrawList::AddImage() API, via ImGui::GetWindowDrawList()->AddImage().
         // - Read https://github.com/ocornut/imgui/blob/master/docs/FAQ.md
         // - Read https://github.com/ocornut/imgui/wiki/Image-Loading-and-Displaying-Examples
-        ImTextureID my_tex_id = io.Fonts->TexID;
-        float my_tex_w = (float)io.Fonts->TexWidth;
-        float my_tex_h = (float)io.Fonts->TexHeight;
+        ImTextureID my_tex_id = io.Fonts->GetTexID();
+        float my_tex_w = (float)io.Fonts->TexData.TexWidth;
+        float my_tex_h = (float)io.Fonts->TexData.TexHeight;
         {
             static bool use_text_color_for_tint = false;
             ImGui::Checkbox("Use Text Color for Tint", &use_text_color_for_tint);
@@ -7740,7 +7743,7 @@ void ImGui::ShowAboutWindow(bool* p_open)
         if (io.BackendFlags & ImGuiBackendFlags_HasSetMousePos)         ImGui::Text(" HasSetMousePos");
         if (io.BackendFlags & ImGuiBackendFlags_RendererHasVtxOffset)   ImGui::Text(" RendererHasVtxOffset");
         ImGui::Separator();
-        ImGui::Text("io.Fonts: %d fonts, Flags: 0x%08X, TexSize: %d,%d", io.Fonts->Fonts.Size, io.Fonts->Flags, io.Fonts->TexWidth, io.Fonts->TexHeight);
+        ImGui::Text("io.Fonts: %d fonts, Flags: 0x%08X, TexSize: %d,%d", io.Fonts->Fonts.Size, io.Fonts->Flags, io.Fonts->TexData.TexWidth, io.Fonts->TexData.TexHeight);
         ImGui::Text("io.DisplaySize: %.2f,%.2f", io.DisplaySize.x, io.DisplaySize.y);
         ImGui::Text("io.DisplayFramebufferScale: %.2f,%.2f", io.DisplayFramebufferScale.x, io.DisplayFramebufferScale.y);
         ImGui::Separator();
@@ -10331,6 +10334,142 @@ void ShowExampleAppAssetsBrowser(bool* p_open)
     IMGUI_DEMO_MARKER("Examples/Assets Browser");
     static ExampleAssetsBrowser assets_browser;
     assets_browser.Draw("Example: Assets Browser", p_open);
+}
+
+#include "imgui_internal.h"
+
+static const char* font_path_prefix = "../../misc/fonts/";
+static const char* fonts[] =
+{
+    "Default (built-in)",
+    "Roboto-Medium.ttf",
+    "Cousine-Regular.ttf",
+    "DroidSans.ttf",
+    "ProggyTiny.ttf",
+};
+
+struct FontDemoState
+{
+    bool    want_rebuild;
+    int     font_index;
+    float   font_size;
+
+    FontDemoState()
+    {
+        want_rebuild = true;
+        font_index = 0;
+        font_size = 13.0f;
+    }
+};
+
+static FontDemoState font_demo_state1;
+static FontDemoState font_demo_state2;
+
+static void RebuildAtlas(FontDemoState& state)
+{
+    ImGuiIO& io = ImGui::GetIO();
+    if (!state.want_rebuild)
+        return;
+    state.want_rebuild = false;
+
+    io.Fonts->Locked = false; // FIXME-TEXUPDATE: #thedmd: remove this
+    io.Fonts->PushTexPage();
+    io.Fonts->Clear();
+
+    ImFontConfig cfg;
+    cfg.SizePixels = state.font_size;
+    cfg.OversampleH = cfg.OversampleV = 1;
+
+    if (state.font_index == 0)
+    {
+        io.Fonts->AddFontDefault(&cfg);
+    }
+    else
+    {
+        char path[256];
+        sprintf(path, "%s%s", font_path_prefix, fonts[state.font_index]);
+        io.Fonts->AddFontFromFileTTF(path, 0.0f, &cfg);
+    }
+    io.Fonts->Build();
+    io.Fonts->Locked = true; // FIXME-TEXUPDATE: #thedmd: remove this
+}
+
+static void ShowFontDemo(FontDemoState& state)
+{
+    ImGuiIO& io = ImGui::GetIO();
+
+    RebuildAtlas(state);
+
+    // FIXME-TEXUPDATE: What is this doing?
+    ImGui::SetCurrentFont(ImGui::GetDefaultFont());
+    ImDrawList* draw_list = ImGui::GetWindowDrawList();
+    draw_list->_CmdHeader.Texture = ImTexture(io.Fonts);
+    draw_list->_OnChangedTexture();
+
+    draw_list = ImGui::GetForegroundDrawList();
+    draw_list->_CmdHeader.Texture = ImTexture(io.Fonts);
+    draw_list->_OnChangedTexture();
+
+    draw_list = ImGui::GetBackgroundDrawList();
+    draw_list->_CmdHeader.Texture = ImTexture(io.Fonts);
+    draw_list->_OnChangedTexture();
+
+    if (ImGui::BeginCombo("Font", fonts[state.font_index]))
+    {
+        for (int i = 0; i < IM_ARRAYSIZE(fonts); ++i)
+        {
+            if (ImGui::Selectable(fonts[i]))
+            {
+                state.font_index = i;
+                state.want_rebuild = true;
+            }
+        }
+
+        ImGui::EndCombo();
+    }
+
+    if (ImGui::SliderFloat("Size", &state.font_size, 6.0f, 48.0f, "%.0f"))
+        state.want_rebuild = true;
+
+    ImFontAtlas* atlas = io.Fonts;
+    //if (ImGui::TreeNode("Atlas texture", "Atlas texture (%dx%d pixels)", atlas->TexWidth, atlas->TexHeight))
+    ImGui::Text("Atlas texture (%dx%d pixels)", atlas->TexData.TexWidth, atlas->TexData.TexHeight);
+    {
+        ImVec4 tint_col = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
+        ImVec4 border_col = ImVec4(1.0f, 1.0f, 1.0f, 0.5f);
+        ImGui::Image(ImTexture(atlas), ImVec2((float)atlas->TexData.TexWidth, (float)atlas->TexData.TexHeight), ImVec2(0, 0), ImVec2(1, 1), tint_col, border_col);
+        //ImGui::TreePop();
+    }
+}
+
+void ImGui::ShowFontDemoWindow()
+{
+    if (ImGui::Begin("Font Test"))
+    {
+        ImGuiIO& io = ImGui::GetIO();
+
+        ImGuiBackendFlags backend_flags = io.BackendFlags;
+        ImGui::Text("Backends: '%s' + '%s'", io.BackendPlatformName ? io.BackendPlatformName : "", io.BackendRendererName ? io.BackendRendererName : "");
+        ImGui::CheckboxFlags("io.BackendFlags: RendererHasTexReload", &backend_flags, ImGuiBackendFlags_RendererHasTexReload);
+        static bool always_rebuild = true;
+
+        ImGui::Checkbox("Rebuild every frame", &always_rebuild);
+        if (always_rebuild)
+            font_demo_state1.want_rebuild = font_demo_state2.want_rebuild = true;
+        ImGui::SameLine(); HelpMarker("Otherwise last rebuilt will be applied to current atlas.");
+
+        ImGui::Separator();
+
+        ImGui::PushID("state1");
+        ShowFontDemo(font_demo_state1);
+        ImGui::PopID();
+
+        ImGui::PushID("state2");
+        ShowFontDemo(font_demo_state2);
+        ImGui::PopID();
+
+        ImGui::End();
+    }
 }
 
 // End of Demo code

--- a/OptiScaler/include/imgui/imgui_impl_dx11.cpp
+++ b/OptiScaler/include/imgui/imgui_impl_dx11.cpp
@@ -15,6 +15,7 @@
 
 // CHANGELOG
 // (minor and older changes stripped away, please see git history for details)
+//  2023-XX-XX: DirectX11: Add support for ImGuiBackendFlags_RendererHasTexReload.
 //  2022-10-11: Using 'nullptr' instead of 'NULL' as per our switch to C++11.
 //  2021-06-29: Reorganized backend to pull data from a single structure to facilitate usage with multiple-contexts (all g_XXXX access changed to bd->XXXX).
 //  2021-05-19: DirectX11: Replaced direct access to ImDrawCmd::TextureId with a call to ImDrawCmd::GetTexID(). (will become a requirement)
@@ -58,6 +59,9 @@ struct ImGui_ImplDX11_Data
     ID3D11Buffer*               pVertexConstantBuffer;
     ID3D11PixelShader*          pPixelShader;
     ID3D11SamplerState*         pFontSampler;
+    ID3D11Texture2D*            pFontTexture;
+    int                         FontTextureWidth;
+    int                         FontTextureHeight;
     ID3D11ShaderResourceView*   pFontTextureView;
     ID3D11RasterizerState*      pRasterizerState;
     ID3D11BlendState*           pBlendState;
@@ -308,46 +312,73 @@ void ImGui_ImplDX11_RenderDrawData(ImDrawData* draw_data)
     ctx->IASetInputLayout(old.InputLayout); if (old.InputLayout) old.InputLayout->Release();
 }
 
-static void ImGui_ImplDX11_CreateFontsTexture()
+static void ImGui_ImplDX11_UpdateFontsTexture()
 {
-    // Build texture atlas
     ImGuiIO& io = ImGui::GetIO();
     ImGui_ImplDX11_Data* bd = ImGui_ImplDX11_GetBackendData();
+
+    // Build texture atlas
     unsigned char* pixels;
     int width, height;
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
+    io.Fonts->MarkClean();
 
-    // Upload texture to graphics system
+    if ((!bd->pFontTextureView) || (bd->FontTextureWidth != width) || (bd->FontTextureHeight != height))
     {
-        D3D11_TEXTURE2D_DESC desc;
-        ZeroMemory(&desc, sizeof(desc));
-        desc.Width = width;
-        desc.Height = height;
-        desc.MipLevels = 1;
-        desc.ArraySize = 1;
-        desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        desc.SampleDesc.Count = 1;
-        desc.Usage = D3D11_USAGE_DEFAULT;
-        desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
-        desc.CPUAccessFlags = 0;
+        // Either we have no texture or the size has changed, so (re-)create the texture
 
-        ID3D11Texture2D* pTexture = nullptr;
-        D3D11_SUBRESOURCE_DATA subResource;
-        subResource.pSysMem = pixels;
-        subResource.SysMemPitch = desc.Width * 4;
-        subResource.SysMemSlicePitch = 0;
-        bd->pd3dDevice->CreateTexture2D(&desc, &subResource, &pTexture);
-        IM_ASSERT(pTexture != nullptr);
+        // Release old texture
+        if (bd->pFontTextureView) { bd->pFontTextureView->Release(); bd->pFontTextureView = nullptr; ImGui::GetIO().Fonts->SetTexID(0); } // We copied g_pFontTextureView to io.Fonts->TexID so let's clear that as well.
+        if (bd->pFontTexture) { bd->pFontTexture->Release(); bd->pFontTexture = nullptr; }
 
-        // Create texture view
-        D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc;
-        ZeroMemory(&srvDesc, sizeof(srvDesc));
-        srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = desc.MipLevels;
-        srvDesc.Texture2D.MostDetailedMip = 0;
-        bd->pd3dDevice->CreateShaderResourceView(pTexture, &srvDesc, &bd->pFontTextureView);
-        pTexture->Release();
+        // Create new texture
+        {
+            D3D11_TEXTURE2D_DESC desc;
+            ZeroMemory(&desc, sizeof(desc));
+            desc.Width = width;
+            desc.Height = height;
+            desc.MipLevels = 1;
+            desc.ArraySize = 1;
+            desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+            desc.SampleDesc.Count = 1;
+            desc.Usage = D3D11_USAGE_DEFAULT;
+            desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+            desc.CPUAccessFlags = 0;
+
+            D3D11_SUBRESOURCE_DATA subResource;
+            subResource.pSysMem = pixels;
+            subResource.SysMemPitch = desc.Width * 4;
+            subResource.SysMemSlicePitch = 0;
+            bd->pd3dDevice->CreateTexture2D(&desc, &subResource, &bd->pFontTexture);
+            IM_ASSERT(bd->pFontTexture != nullptr);
+
+            // Create texture view
+            D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc;
+            ZeroMemory(&srvDesc, sizeof(srvDesc));
+            srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+            srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+            srvDesc.Texture2D.MipLevels = desc.MipLevels;
+            srvDesc.Texture2D.MostDetailedMip = 0;
+            bd->pd3dDevice->CreateShaderResourceView(bd->pFontTexture, &srvDesc, &bd->pFontTextureView);
+        }
+
+        // Store size
+        bd->FontTextureWidth = width;
+        bd->FontTextureHeight = height;
+    }
+    else
+    {
+        // Upload new atlas data
+
+        D3D11_BOX box;
+        box.left = 0;
+        box.right = width;
+        box.top = 0;
+        box.bottom = height;
+        box.front = 0;
+        box.back = 1;
+
+        bd->pd3dDeviceContext->UpdateSubresource(bd->pFontTexture, 0, &box, pixels, bd->FontTextureWidth * 4, 0);
     }
 
     // Store our identifier
@@ -355,6 +386,7 @@ static void ImGui_ImplDX11_CreateFontsTexture()
 
     // Create texture sampler
     // (Bilinear sampling is required by default. Set 'io.Fonts->Flags |= ImFontAtlasFlags_NoBakedLines' or 'style.AntiAliasedLinesUseTex = false' to allow point/nearest sampling)
+    if (!bd->pFontSampler)
     {
         D3D11_SAMPLER_DESC desc;
         ZeroMemory(&desc, sizeof(desc));
@@ -519,7 +551,7 @@ bool    ImGui_ImplDX11_CreateDeviceObjects()
         bd->pd3dDevice->CreateDepthStencilState(&desc, &bd->pDepthStencilState);
     }
 
-    ImGui_ImplDX11_CreateFontsTexture();
+    ImGui_ImplDX11_UpdateFontsTexture();
 
     return true;
 }
@@ -532,6 +564,7 @@ void    ImGui_ImplDX11_InvalidateDeviceObjects()
 
     if (bd->pFontSampler)           { bd->pFontSampler->Release(); bd->pFontSampler = nullptr; }
     if (bd->pFontTextureView)       { bd->pFontTextureView->Release(); bd->pFontTextureView = nullptr; ImGui::GetIO().Fonts->SetTexID(0); } // We copied data->pFontTextureView to io.Fonts->TexID so let's clear that as well.
+    if (bd->pFontTexture)           { bd->pFontTexture->Release(); bd->pFontTexture = nullptr; }
     if (bd->pIB)                    { bd->pIB->Release(); bd->pIB = nullptr; }
     if (bd->pVB)                    { bd->pVB->Release(); bd->pVB = nullptr; }
     if (bd->pBlendState)            { bd->pBlendState->Release(); bd->pBlendState = nullptr; }
@@ -554,6 +587,7 @@ bool    ImGui_ImplDX11_Init(ID3D11Device* device, ID3D11DeviceContext* device_co
     io.BackendRendererUserData = (void*)bd;
     io.BackendRendererName = "imgui_impl_dx11";
     io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;  // We can honor the ImDrawCmd::VtxOffset field, allowing for large meshes.
+    io.BackendFlags |= ImGuiBackendFlags_RendererHasTexReload;  // We support font atlas texture reloading (IsDirty() check in ImGui_ImplDX11_NewFrame)
 
     // Get factory from device
     IDXGIDevice* pDXGIDevice = nullptr;
@@ -599,6 +633,10 @@ void ImGui_ImplDX11_NewFrame()
 
     if (!bd->pFontSampler)
         ImGui_ImplDX11_CreateDeviceObjects();
+
+    ImGuiIO& io = ImGui::GetIO();
+    if (io.Fonts->IsDirty())
+        ImGui_ImplDX11_UpdateFontsTexture();
 }
 
 //-----------------------------------------------------------------------------

--- a/OptiScaler/include/imgui/imgui_impl_dx12.cpp
+++ b/OptiScaler/include/imgui/imgui_impl_dx12.cpp
@@ -23,6 +23,7 @@
 
 // CHANGELOG
 // (minor and older changes stripped away, please see git history for details)
+//  2023-XX-XX: *BREAKING CHANGE*: DirectX12: Changed ImGui_ImplDX12_CreateFontsTexture() to ImGui_ImplDX12_UpdateFontsTexture(), which should be called at the start of the frame when ImGui::GetIO().Fonts->IsDirty() is true to reupload the font texture. ImGuiBackendFlags_RendererHasTexReload should be set once this is implemented.
 //  2022-10-11: Using 'nullptr' instead of 'NULL' as per our switch to C++11.
 //  2021-06-29: Reorganized backend to pull data from a single structure to facilitate usage with multiple-contexts (all g_XXXX access changed to bd->XXXX).
 //  2021-05-19: DirectX12: Replaced direct access to ImDrawCmd::TextureId with a call to ImDrawCmd::GetTexID(). (will become a requirement)
@@ -62,6 +63,8 @@ struct ImGui_ImplDX12_Data
     ID3D12PipelineState*        pPipelineState;
     DXGI_FORMAT                 RTVFormat;
     ID3D12Resource*             pFontTextureResource;
+    int                         FontTextureWidth;
+    int                         FontTextureHeight;
     D3D12_CPU_DESCRIPTOR_HANDLE hFontSrvCpuDescHandle;
     D3D12_GPU_DESCRIPTOR_HANDLE hFontSrvGpuDescHandle;
     ID3D12DescriptorHeap*       pd3dSrvDescHeap;
@@ -287,7 +290,7 @@ void ImGui_ImplDX12_RenderDrawData(ImDrawData* draw_data, ID3D12GraphicsCommandL
     }
 }
 
-static void ImGui_ImplDX12_CreateFontsTexture()
+void ImGui_ImplDX12_UpdateFontsTexture()
 {
     // Build texture atlas
     ImGuiIO& io = ImGui::GetIO();
@@ -295,9 +298,13 @@ static void ImGui_ImplDX12_CreateFontsTexture()
     unsigned char* pixels;
     int width, height;
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
+    io.Fonts->MarkClean();
 
-    // Upload texture to graphics system
+    bool need_barrier_before_copy = true; // Do we need a resource barrier before we copy new data in?
+
+    if ((!bd->pFontTextureResource) || (bd->FontTextureWidth != width) || (bd->FontTextureHeight != height))
     {
+        // Either we have no texture or the size has changed, so (re-)create the texture
         D3D12_HEAP_PROPERTIES props;
         memset(&props, 0, sizeof(D3D12_HEAP_PROPERTIES));
         props.Type = D3D12_HEAP_TYPE_DEFAULT;
@@ -322,8 +329,42 @@ static void ImGui_ImplDX12_CreateFontsTexture()
         bd->pd3dDevice->CreateCommittedResource(&props, D3D12_HEAP_FLAG_NONE, &desc,
             D3D12_RESOURCE_STATE_COPY_DEST, nullptr, IID_PPV_ARGS(&pTexture));
 
+        // Create SRV
+        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc;
+        ZeroMemory(&srvDesc, sizeof(srvDesc));
+        srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+        srvDesc.Texture2D.MipLevels = desc.MipLevels;
+        srvDesc.Texture2D.MostDetailedMip = 0;
+        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+        bd->pd3dDevice->CreateShaderResourceView(pTexture, &srvDesc, bd->hFontSrvCpuDescHandle);
+        SafeRelease(bd->pFontTextureResource);
+        bd->pFontTextureResource = pTexture;
+
+        bd->FontTextureWidth = width;
+        bd->FontTextureHeight = height;
+
+        need_barrier_before_copy = false; // Because this is a newly-created texture it will be in D3D12_RESOURCE_STATE_COMMON and thus we don't need a barrier
+    }
+
+    // Store our identifier
+    // READ THIS IF THE STATIC_ASSERT() TRIGGERS:
+    // - Important: to compile on 32-bit systems, this backend requires code to be compiled with '#define ImTextureID ImU64'.
+    // - This is because we need ImTextureID to carry a 64-bit value and by default ImTextureID is defined as void*.
+    // [Solution 1] IDE/msbuild: in "Properties/C++/Preprocessor Definitions" add 'ImTextureID=ImU64' (this is what we do in the 'example_win32_direct12/example_win32_direct12.vcxproj' project file)
+    // [Solution 2] IDE/msbuild: in "Properties/C++/Preprocessor Definitions" add 'IMGUI_USER_CONFIG="my_imgui_config.h"' and inside 'my_imgui_config.h' add '#define ImTextureID ImU64' and as many other options as you like.
+    // [Solution 3] IDE/msbuild: edit imconfig.h and add '#define ImTextureID ImU64' (prefer solution 2 to create your own config file!)
+    // [Solution 4] command-line: add '/D ImTextureID=ImU64' to your cl.exe command-line (this is what we do in the example_win32_direct12/build_win32.bat file)
+    static_assert(sizeof(ImTextureID) >= sizeof(bd->hFontSrvGpuDescHandle.ptr), "Can't pack descriptor handle into TexID, 32-bit not supported yet.");
+    io.Fonts->SetTexID((ImTextureID)bd->hFontSrvGpuDescHandle.ptr);
+
+    // Upload texture
+    {
         UINT uploadPitch = (width * 4 + D3D12_TEXTURE_DATA_PITCH_ALIGNMENT - 1u) & ~(D3D12_TEXTURE_DATA_PITCH_ALIGNMENT - 1u);
         UINT uploadSize = height * uploadPitch;
+
+        D3D12_RESOURCE_DESC desc;
+        ZeroMemory(&desc, sizeof(desc));
         desc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
         desc.Alignment = 0;
         desc.Width = uploadSize;
@@ -336,6 +377,8 @@ static void ImGui_ImplDX12_CreateFontsTexture()
         desc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
         desc.Flags = D3D12_RESOURCE_FLAG_NONE;
 
+        D3D12_HEAP_PROPERTIES props;
+        memset(&props, 0, sizeof(D3D12_HEAP_PROPERTIES));
         props.Type = D3D12_HEAP_TYPE_UPLOAD;
         props.CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN;
         props.MemoryPoolPreference = D3D12_MEMORY_POOL_UNKNOWN;
@@ -363,17 +406,11 @@ static void ImGui_ImplDX12_CreateFontsTexture()
         srcLocation.PlacedFootprint.Footprint.RowPitch = uploadPitch;
 
         D3D12_TEXTURE_COPY_LOCATION dstLocation = {};
-        dstLocation.pResource = pTexture;
+        dstLocation.pResource = bd->pFontTextureResource;
         dstLocation.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
         dstLocation.SubresourceIndex = 0;
 
-        D3D12_RESOURCE_BARRIER barrier = {};
-        barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
-        barrier.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
-        barrier.Transition.pResource   = pTexture;
-        barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
-        barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
-        barrier.Transition.StateAfter  = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+        // Create temporary command list and execute immediately
 
         ID3D12Fence* fence = nullptr;
         hr = bd->pd3dDevice->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&fence));
@@ -399,8 +436,30 @@ static void ImGui_ImplDX12_CreateFontsTexture()
         hr = bd->pd3dDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_DIRECT, cmdAlloc, nullptr, IID_PPV_ARGS(&cmdList));
         IM_ASSERT(SUCCEEDED(hr));
 
+        if (need_barrier_before_copy)
+        {
+            D3D12_RESOURCE_BARRIER barrier = {};
+            barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+            barrier.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+            barrier.Transition.pResource = bd->pFontTextureResource;
+            barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+            barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+            barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_DEST;
+            cmdList->ResourceBarrier(1, &barrier);
+        }
+
         cmdList->CopyTextureRegion(&dstLocation, 0, 0, 0, &srcLocation, nullptr);
-        cmdList->ResourceBarrier(1, &barrier);
+
+        {
+            D3D12_RESOURCE_BARRIER barrier = {};
+            barrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+            barrier.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+            barrier.Transition.pResource = bd->pFontTextureResource;
+            barrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+            barrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
+            barrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+            cmdList->ResourceBarrier(1, &barrier);
+        }
 
         hr = cmdList->Close();
         IM_ASSERT(SUCCEEDED(hr));
@@ -418,30 +477,7 @@ static void ImGui_ImplDX12_CreateFontsTexture()
         CloseHandle(event);
         fence->Release();
         uploadBuffer->Release();
-
-        // Create texture view
-        D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc;
-        ZeroMemory(&srvDesc, sizeof(srvDesc));
-        srvDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-        srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-        srvDesc.Texture2D.MipLevels = desc.MipLevels;
-        srvDesc.Texture2D.MostDetailedMip = 0;
-        srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
-        bd->pd3dDevice->CreateShaderResourceView(pTexture, &srvDesc, bd->hFontSrvCpuDescHandle);
-        SafeRelease(bd->pFontTextureResource);
-        bd->pFontTextureResource = pTexture;
     }
-
-    // Store our identifier
-    // READ THIS IF THE STATIC_ASSERT() TRIGGERS:
-    // - Important: to compile on 32-bit systems, this backend requires code to be compiled with '#define ImTextureID ImU64'.
-    // - This is because we need ImTextureID to carry a 64-bit value and by default ImTextureID is defined as void*.
-    // [Solution 1] IDE/msbuild: in "Properties/C++/Preprocessor Definitions" add 'ImTextureID=ImU64' (this is what we do in the 'example_win32_direct12/example_win32_direct12.vcxproj' project file)
-    // [Solution 2] IDE/msbuild: in "Properties/C++/Preprocessor Definitions" add 'IMGUI_USER_CONFIG="my_imgui_config.h"' and inside 'my_imgui_config.h' add '#define ImTextureID ImU64' and as many other options as you like.
-    // [Solution 3] IDE/msbuild: edit imconfig.h and add '#define ImTextureID ImU64' (prefer solution 2 to create your own config file!)
-    // [Solution 4] command-line: add '/D ImTextureID=ImU64' to your cl.exe command-line (this is what we do in the example_win32_direct12/build_win32.bat file)
-    static_assert(sizeof(ImTextureID) >= sizeof(bd->hFontSrvGpuDescHandle.ptr), "Can't pack descriptor handle into TexID, 32-bit not supported yet.");
-    io.Fonts->SetTexID((ImTextureID)bd->hFontSrvGpuDescHandle.ptr);
 }
 
 bool    ImGui_ImplDX12_CreateDeviceObjects()
@@ -673,7 +709,7 @@ bool    ImGui_ImplDX12_CreateDeviceObjects()
     if (result_pipeline_state != S_OK)
         return false;
 
-    ImGui_ImplDX12_CreateFontsTexture();
+    ImGui_ImplDX12_UpdateFontsTexture();
 
     return true;
 }
@@ -710,6 +746,7 @@ bool ImGui_ImplDX12_Init(ID3D12Device* device, int num_frames_in_flight, DXGI_FO
     io.BackendRendererUserData = (void*)bd;
     io.BackendRendererName = "imgui_impl_dx12";
     io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;  // We can honor the ImDrawCmd::VtxOffset field, allowing for large meshes.
+    // Note that we explicitly do *not* set ImGuiBackendFlags_RendererHasTexReload here, because in DX12 that requires support in the caller as well, so we leave setting it (or not) up to that code.
 
     bd->pd3dDevice = device;
     bd->RTVFormat = rtv_format;

--- a/OptiScaler/include/imgui/imgui_impl_dx12.h
+++ b/OptiScaler/include/imgui/imgui_impl_dx12.h
@@ -38,6 +38,7 @@ IMGUI_IMPL_API bool     ImGui_ImplDX12_Init(ID3D12Device* device, int num_frames
 IMGUI_IMPL_API void     ImGui_ImplDX12_Shutdown();
 IMGUI_IMPL_API void     ImGui_ImplDX12_NewFrame();
 IMGUI_IMPL_API void     ImGui_ImplDX12_RenderDrawData(ImDrawData* draw_data, ID3D12GraphicsCommandList* graphics_command_list);
+IMGUI_IMPL_API void     ImGui_ImplDX12_UpdateFontsTexture(); // This should be called when the font texture needs updating (if ImGuiBackendFlags_RendererHasTexReload was set), with the GPU idle. It will perform the update using a temporary command list, and block internally until it completes.
 
 // Use if you want to reset your rendering device without losing Dear ImGui state.
 IMGUI_IMPL_API void     ImGui_ImplDX12_InvalidateDeviceObjects();

--- a/OptiScaler/include/imgui/imgui_impl_vulkan.cpp
+++ b/OptiScaler/include/imgui/imgui_impl_vulkan.cpp
@@ -46,6 +46,7 @@
 //              ImGui_ImplVulkan_CreateFontsTexture() is automatically called by NewFrame() the first time.
 //              You can call ImGui_ImplVulkan_CreateFontsTexture() again to recreate the font atlas texture.
 //              Added ImGui_ImplVulkan_DestroyFontsTexture() but you probably never need to call this.
+//  2023-XX-XX: *BREAKING CHANGE*: Vulkan: Changed ImGui_ImplVulkan_CreateFontsTexture() to ImGui_ImplVulkan_UpdateFontsTexture(), which should be called at the start of the frame when ImGui::GetIO().Fonts->IsDirty() is true to reupload the font texture. ImGuiBackendFlags_RendererHasTexReload should be set once this is implemented.
 //  2023-07-04: Vulkan: Added optional support for VK_KHR_dynamic_rendering. User needs to set init_info->UseDynamicRendering = true and init_info->ColorAttachmentFormat.
 //  2023-01-02: Vulkan: Fixed sampler passed to ImGui_ImplVulkan_AddTexture() not being honored + removed a bunch of duplicate code.
 //  2022-10-11: Using 'nullptr' instead of 'NULL' as per our switch to C++11.
@@ -232,8 +233,11 @@ struct ImGui_ImplVulkan_Data
     VkImage                     FontImage;
     VkImageView                 FontView;
     VkDescriptorSet             FontDescriptorSet;
+
     VkCommandPool               FontCommandPool;
     VkCommandBuffer             FontCommandBuffer;
+    int                         FontTextureWidth;
+    int                         FontTextureHeight;
 
     // Render buffers for main window
     ImGui_ImplVulkan_WindowRenderBuffers MainWindowRenderBuffers;
@@ -586,11 +590,11 @@ void ImGui_ImplVulkan_RenderDrawData(ImDrawData* draw_data, VkCommandBuffer comm
                 vkCmdSetScissor(command_buffer, 0, 1, &scissor);
 
                 // Bind DescriptorSet with font or user texture
-                VkDescriptorSet desc_set[1] = { (VkDescriptorSet)pcmd->TextureId };
+                VkDescriptorSet desc_set[1] = { (VkDescriptorSet)pcmd->Texture.GetID() };
                 if (sizeof(ImTextureID) < sizeof(ImU64))
                 {
                     // We don't support texture switches if ImTextureID hasn't been redefined to be 64-bit. Do a flaky check that other textures haven't been used.
-                    IM_ASSERT(pcmd->TextureId == (ImTextureID)bd->FontDescriptorSet);
+                    IM_ASSERT(pcmd->Texture.GetID() == (ImTextureID)bd->FontDescriptorSet);
                     desc_set[0] = bd->FontDescriptorSet;
                 }
                 vkCmdBindDescriptorSets(command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, bd->PipelineLayout, 0, 1, desc_set, 0, nullptr);
@@ -614,7 +618,7 @@ void ImGui_ImplVulkan_RenderDrawData(ImDrawData* draw_data, VkCommandBuffer comm
     vkCmdSetScissor(command_buffer, 0, 1, &scissor);
 }
 
-bool ImGui_ImplVulkan_CreateFontsTexture()
+bool ImGui_ImplVulkan_UpdateFontsTexture()
 {
     ImGuiIO& io = ImGui::GetIO();
     ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
@@ -661,54 +665,79 @@ bool ImGui_ImplVulkan_CreateFontsTexture()
     unsigned char* pixels;
     int width, height;
     io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
+    io.Fonts->MarkClean();
+
+    if ((!bd->FontView) || (bd->FontTextureWidth != width) || (bd->FontTextureHeight != height))
+    {
+        // Either we have no texture or the size has changed, so (re-)create the texture
+        //if (bd->FontView) { vkDestroyImageView(v->Device, bd->FontView, v->Allocator); bd->FontView = VK_NULL_HANDLE; }
+        //if (bd->FontImage) { vkDestroyImage(v->Device, bd->FontImage, v->Allocator); bd->FontImage = VK_NULL_HANDLE; }
+        //if (bd->FontMemory) { vkFreeMemory(v->Device, bd->FontMemory, v->Allocator); bd->FontMemory = VK_NULL_HANDLE; }
+
+        // Create the Image:
+        {
+            VkImageCreateInfo info = {};
+            info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+            info.imageType = VK_IMAGE_TYPE_2D;
+            info.format = VK_FORMAT_R8G8B8A8_UNORM;
+            info.extent.width = width;
+            info.extent.height = height;
+            info.extent.depth = 1;
+            info.mipLevels = 1;
+            info.arrayLayers = 1;
+            info.samples = VK_SAMPLE_COUNT_1_BIT;
+            info.tiling = VK_IMAGE_TILING_OPTIMAL;
+            info.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+            info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+            info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+            err = vkCreateImage(v->Device, &info, v->Allocator, &bd->FontImage);
+            check_vk_result(err);
+            VkMemoryRequirements req;
+            vkGetImageMemoryRequirements(v->Device, bd->FontImage, &req);
+            VkMemoryAllocateInfo alloc_info = {};
+            alloc_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+            alloc_info.allocationSize = IM_MAX(v->MinAllocationSize, req.size);
+            alloc_info.memoryTypeIndex = ImGui_ImplVulkan_MemoryType(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, req.memoryTypeBits);
+            err = vkAllocateMemory(v->Device, &alloc_info, v->Allocator, &bd->FontMemory);
+            check_vk_result(err);
+            err = vkBindImageMemory(v->Device, bd->FontImage, bd->FontMemory, 0);
+            check_vk_result(err);
+        }
+
+        // Create the Image View:
+        {
+            VkImageViewCreateInfo info = {};
+            info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+            info.image = bd->FontImage;
+            info.viewType = VK_IMAGE_VIEW_TYPE_2D;
+            info.format = VK_FORMAT_R8G8B8A8_UNORM;
+            info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            info.subresourceRange.levelCount = 1;
+            info.subresourceRange.layerCount = 1;
+            err = vkCreateImageView(v->Device, &info, v->Allocator, &bd->FontView);
+            check_vk_result(err);
+        }
+
+        // Create the Descriptor Set:
+        bd->FontDescriptorSet = (VkDescriptorSet)ImGui_ImplVulkan_AddTexture(bd->FontSampler, bd->FontView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+
+        // Update the Descriptor Set:
+        {
+            VkDescriptorImageInfo desc_image[1] = {};
+            desc_image[0].sampler = bd->FontSampler;
+            desc_image[0].imageView = bd->FontView;
+            desc_image[0].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            VkWriteDescriptorSet write_desc[1] = {};
+            write_desc[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            write_desc[0].dstSet = bd->FontDescriptorSet;
+            write_desc[0].descriptorCount = 1;
+            write_desc[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            write_desc[0].pImageInfo = desc_image;
+            vkUpdateDescriptorSets(v->Device, 1, write_desc, 0, nullptr);
+        }
+    }
+
     size_t upload_size = width * height * 4 * sizeof(char);
-
-    // Create the Image:
-    {
-        VkImageCreateInfo info = {};
-        info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-        info.imageType = VK_IMAGE_TYPE_2D;
-        info.format = VK_FORMAT_R8G8B8A8_UNORM;
-        info.extent.width = width;
-        info.extent.height = height;
-        info.extent.depth = 1;
-        info.mipLevels = 1;
-        info.arrayLayers = 1;
-        info.samples = VK_SAMPLE_COUNT_1_BIT;
-        info.tiling = VK_IMAGE_TILING_OPTIMAL;
-        info.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-        info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-        info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-        err = vkCreateImage(v->Device, &info, v->Allocator, &bd->FontImage);
-        check_vk_result(err);
-        VkMemoryRequirements req;
-        vkGetImageMemoryRequirements(v->Device, bd->FontImage, &req);
-        VkMemoryAllocateInfo alloc_info = {};
-        alloc_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-        alloc_info.allocationSize = IM_MAX(v->MinAllocationSize, req.size);
-        alloc_info.memoryTypeIndex = ImGui_ImplVulkan_MemoryType(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, req.memoryTypeBits);
-        err = vkAllocateMemory(v->Device, &alloc_info, v->Allocator, &bd->FontMemory);
-        check_vk_result(err);
-        err = vkBindImageMemory(v->Device, bd->FontImage, bd->FontMemory, 0);
-        check_vk_result(err);
-    }
-
-    // Create the Image View:
-    {
-        VkImageViewCreateInfo info = {};
-        info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-        info.image = bd->FontImage;
-        info.viewType = VK_IMAGE_VIEW_TYPE_2D;
-        info.format = VK_FORMAT_R8G8B8A8_UNORM;
-        info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-        info.subresourceRange.levelCount = 1;
-        info.subresourceRange.layerCount = 1;
-        err = vkCreateImageView(v->Device, &info, v->Allocator, &bd->FontView);
-        check_vk_result(err);
-    }
-
-    // Create the Descriptor Set:
-    bd->FontDescriptorSet = (VkDescriptorSet)ImGui_ImplVulkan_AddTexture(bd->FontSampler, bd->FontView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
     // Create the Upload Buffer:
     VkDeviceMemory upload_buffer_memory;
@@ -739,7 +768,7 @@ bool ImGui_ImplVulkan_CreateFontsTexture()
         char* map = nullptr;
         err = vkMapMemory(v->Device, upload_buffer_memory, 0, upload_size, 0, (void**)(&map));
         check_vk_result(err);
-        memcpy(map, pixels, upload_size);
+        memcpy(map, pixels, upload_size); // Fast path for full image upload
         VkMappedMemoryRange range[1] = {};
         range[0].sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
         range[0].memory = upload_buffer_memory;
@@ -767,9 +796,14 @@ bool ImGui_ImplVulkan_CreateFontsTexture()
         VkBufferImageCopy region = {};
         region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
         region.imageSubresource.layerCount = 1;
+        region.imageOffset.x = 0;
+        region.imageOffset.y = 0;
         region.imageExtent.width = width;
         region.imageExtent.height = height;
         region.imageExtent.depth = 1;
+        region.bufferOffset = 0;
+        region.bufferRowLength = width;
+        region.bufferImageHeight = height;
         vkCmdCopyBufferToImage(bd->FontCommandBuffer, upload_buffer, bd->FontImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
 
         VkImageMemoryBarrier use_barrier[1] = {};
@@ -789,6 +823,8 @@ bool ImGui_ImplVulkan_CreateFontsTexture()
 
     // Store our identifier
     io.Fonts->SetTexID((ImTextureID)bd->FontDescriptorSet);
+    bd->FontTextureWidth = width;
+    bd->FontTextureHeight = height;
 
     // End command buffer
     VkSubmitInfo end_info = {};
@@ -1100,6 +1136,7 @@ bool    ImGui_ImplVulkan_Init(ImGui_ImplVulkan_InitInfo* info)
     io.BackendRendererUserData = (void*)bd;
     io.BackendRendererName = "imgui_impl_vulkan";
     io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;  // We can honor the ImDrawCmd::VtxOffset field, allowing for large meshes.
+    // Note that we explicitly do *not* set ImGuiBackendFlags_RendererHasTexReload here, because in Vulkan that requires support in the caller as well, so we leave setting it (or not) up to that code.
 
     IM_ASSERT(info->Instance != VK_NULL_HANDLE);
     IM_ASSERT(info->PhysicalDevice != VK_NULL_HANDLE);
@@ -1136,8 +1173,10 @@ void ImGui_ImplVulkan_NewFrame()
     ImGui_ImplVulkan_Data* bd = ImGui_ImplVulkan_GetBackendData();
     IM_ASSERT(bd != nullptr && "Context or backend not initialized! Did you call ImGui_ImplVulkan_Init()?");
 
-    if (!bd->FontDescriptorSet)
-        ImGui_ImplVulkan_CreateFontsTexture();
+    // Upload Fonts
+    ImGuiIO& io = ImGui::GetIO();
+    if (!bd->FontDescriptorSet || io.Fonts->IsDirty())
+        ImGui_ImplVulkan_UpdateFontsTexture();
 }
 
 void ImGui_ImplVulkan_SetMinImageCount(uint32_t min_image_count)

--- a/OptiScaler/include/imgui/imgui_impl_vulkan.h
+++ b/OptiScaler/include/imgui/imgui_impl_vulkan.h
@@ -103,7 +103,7 @@ IMGUI_IMPL_API bool         ImGui_ImplVulkan_Init(ImGui_ImplVulkan_InitInfo* inf
 IMGUI_IMPL_API void         ImGui_ImplVulkan_Shutdown();
 IMGUI_IMPL_API void         ImGui_ImplVulkan_NewFrame();
 IMGUI_IMPL_API void         ImGui_ImplVulkan_RenderDrawData(ImDrawData* draw_data, VkCommandBuffer command_buffer, VkPipeline pipeline = VK_NULL_HANDLE);
-IMGUI_IMPL_API bool         ImGui_ImplVulkan_CreateFontsTexture();
+IMGUI_IMPL_API bool         ImGui_ImplVulkan_UpdateFontsTexture();
 IMGUI_IMPL_API void         ImGui_ImplVulkan_DestroyFontsTexture();
 IMGUI_IMPL_API void         ImGui_ImplVulkan_SetMinImageCount(uint32_t min_image_count); // To override MinImageCount after initialization (e.g. if swap chain is recreated)
 

--- a/OptiScaler/include/imgui/imgui_internal.h
+++ b/OptiScaler/include/imgui/imgui_internal.h
@@ -3532,7 +3532,7 @@ namespace ImGui
     IMGUI_API void          TextEx(const char* text, const char* text_end = NULL, ImGuiTextFlags flags = 0);
     IMGUI_API bool          ButtonEx(const char* label, const ImVec2& size_arg = ImVec2(0, 0), ImGuiButtonFlags flags = 0);
     IMGUI_API bool          ArrowButtonEx(const char* str_id, ImGuiDir dir, ImVec2 size_arg, ImGuiButtonFlags flags = 0);
-    IMGUI_API bool          ImageButtonEx(ImGuiID id, ImTextureID texture_id, const ImVec2& image_size, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& bg_col, const ImVec4& tint_col, ImGuiButtonFlags flags = 0);
+    IMGUI_API bool          ImageButtonEx(ImGuiID id, ImTexture texture, const ImVec2& image_size, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& bg_col, const ImVec4& tint_col, ImGuiButtonFlags flags = 0);
     IMGUI_API void          SeparatorEx(ImGuiSeparatorFlags flags, float thickness = 1.0f);
     IMGUI_API void          SeparatorTextEx(ImGuiID id, const char* label, const char* label_end, float extra_width);
     IMGUI_API bool          CheckboxFlags(const char* label, ImS64* flags, ImS64 flags_value);

--- a/OptiScaler/include/imgui/imgui_widgets.cpp
+++ b/OptiScaler/include/imgui/imgui_widgets.cpp
@@ -1047,7 +1047,7 @@ bool ImGui::ScrollbarEx(const ImRect& bb_frame, ImGuiID id, ImGuiAxis axis, ImS6
 
 // - Read about ImTextureID here: https://github.com/ocornut/imgui/wiki/Image-Loading-and-Displaying-Examples
 // - 'uv0' and 'uv1' are texture coordinates. Read about them from the same link above.
-void ImGui::Image(ImTextureID user_texture_id, const ImVec2& image_size, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& tint_col, const ImVec4& border_col)
+void ImGui::Image(ImTexture texture, const ImVec2& image_size, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& tint_col, const ImVec4& border_col)
 {
     ImGuiWindow* window = GetCurrentWindow();
     if (window->SkipItems)
@@ -1063,12 +1063,17 @@ void ImGui::Image(ImTextureID user_texture_id, const ImVec2& image_size, const I
     // Render
     if (border_size > 0.0f)
         window->DrawList->AddRect(bb.Min, bb.Max, GetColorU32(border_col), 0.0f, ImDrawFlags_None, border_size);
-    window->DrawList->AddImage(user_texture_id, bb.Min + padding, bb.Max - padding, uv0, uv1, GetColorU32(tint_col));
+    window->DrawList->AddImage(texture, bb.Min + padding, bb.Max - padding, uv0, uv1, GetColorU32(tint_col));
+}
+
+void ImGui::Image(ImTextureID user_texture_id, const ImVec2& image_size, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& tint_col, const ImVec4& border_col)
+{
+    Image(ImTexture(user_texture_id), image_size, uv0, uv1, tint_col, border_col);
 }
 
 // ImageButton() is flawed as 'id' is always derived from 'texture_id' (see #2464 #1390)
 // We provide this internal helper to write your own variant while we figure out how to redesign the public ImageButton() API.
-bool ImGui::ImageButtonEx(ImGuiID id, ImTextureID texture_id, const ImVec2& image_size, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& bg_col, const ImVec4& tint_col, ImGuiButtonFlags flags)
+bool ImGui::ImageButtonEx(ImGuiID id, ImTexture texture, const ImVec2& image_size, const ImVec2& uv0, const ImVec2& uv1, const ImVec4& bg_col, const ImVec4& tint_col, ImGuiButtonFlags flags)
 {
     ImGuiContext& g = *GImGui;
     ImGuiWindow* window = GetCurrentWindow();
@@ -1090,7 +1095,7 @@ bool ImGui::ImageButtonEx(ImGuiID id, ImTextureID texture_id, const ImVec2& imag
     RenderFrame(bb.Min, bb.Max, col, true, ImClamp((float)ImMin(padding.x, padding.y), 0.0f, g.Style.FrameRounding));
     if (bg_col.w > 0.0f)
         window->DrawList->AddRectFilled(bb.Min + padding, bb.Max - padding, GetColorU32(bg_col));
-    window->DrawList->AddImage(texture_id, bb.Min + padding, bb.Max - padding, uv0, uv1, GetColorU32(tint_col));
+    window->DrawList->AddImage(texture, bb.Min + padding, bb.Max - padding, uv0, uv1, GetColorU32(tint_col));
 
     return pressed;
 }
@@ -1103,7 +1108,7 @@ bool ImGui::ImageButton(const char* str_id, ImTextureID user_texture_id, const I
     if (window->SkipItems)
         return false;
 
-    return ImageButtonEx(window->GetID(str_id), user_texture_id, image_size, uv0, uv1, bg_col, tint_col);
+    return ImageButtonEx(window->GetID(str_id), ImTexture(user_texture_id), image_size, uv0, uv1, bg_col, tint_col);
 }
 
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
@@ -1124,6 +1129,10 @@ bool ImGui::ImageButton(ImTextureID user_texture_id, const ImVec2& size, const I
         PopStyleVar();
     PopID();
     return ret;
+}
+bool ImGui::ImageButton(ImTextureID user_texture_id, const ImVec2& size, const ImVec2& uv0, const ImVec2& uv1, int frame_padding, const ImVec4& bg_col, const ImVec4& tint_col)
+{
+    return ImageButton(ImTexture(user_texture_id), size, uv0, uv1, frame_padding, bg_col, tint_col);
 }
 */
 #endif // #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS

--- a/OptiScaler/include/imgui/misc/freetype/imgui_freetype.cpp
+++ b/OptiScaler/include/imgui/misc/freetype/imgui_freetype.cpp
@@ -437,8 +437,7 @@ bool ImFontAtlasBuildWithFreeTypeEx(FT_Library ft_library, ImFontAtlas* atlas, u
     ImFontAtlasBuildInit(atlas);
 
     // Clear atlas
-    atlas->TexID = 0;
-    atlas->TexWidth = atlas->TexHeight = 0;
+    atlas->TexData = ImTextureData();
     atlas->TexUvScale = ImVec2(0.0f, 0.0f);
     atlas->TexUvWhitePixel = ImVec2(0.0f, 0.0f);
     atlas->ClearTexData();
@@ -617,20 +616,20 @@ bool ImFontAtlasBuildWithFreeTypeEx(FT_Library ft_library, ImFontAtlas* atlas, u
     // The exact width doesn't really matter much, but some API/GPU have texture size limitations and increasing width can decrease height.
     // User can override TexDesiredWidth and TexGlyphPadding if they wish, otherwise we use a simple heuristic to select the width based on expected surface.
     const int surface_sqrt = (int)ImSqrt((float)total_surface) + 1;
-    atlas->TexHeight = 0;
+    atlas->TexData.TexHeight = 0;
     if (atlas->TexDesiredWidth > 0)
-        atlas->TexWidth = atlas->TexDesiredWidth;
+        atlas->TexData.TexWidth = atlas->TexDesiredWidth;
     else
-        atlas->TexWidth = (surface_sqrt >= 4096 * 0.7f) ? 4096 : (surface_sqrt >= 2048 * 0.7f) ? 2048 : (surface_sqrt >= 1024 * 0.7f) ? 1024 : 512;
+        atlas->TexData.TexWidth = (surface_sqrt >= 4096 * 0.7f) ? 4096 : (surface_sqrt >= 2048 * 0.7f) ? 2048 : (surface_sqrt >= 1024 * 0.7f) ? 1024 : 512;
 
     // 5. Start packing
     // Pack our extra data rectangles first, so it will be on the upper-left corner of our texture (UV will have small values).
     const int TEX_HEIGHT_MAX = 1024 * 32;
-    const int num_nodes_for_packing_algorithm = atlas->TexWidth - atlas->TexGlyphPadding;
+    const int num_nodes_for_packing_algorithm = atlas->TexData.TexWidth - atlas->TexGlyphPadding;
     ImVector<stbrp_node> pack_nodes;
     pack_nodes.resize(num_nodes_for_packing_algorithm);
     stbrp_context pack_context;
-    stbrp_init_target(&pack_context, atlas->TexWidth - atlas->TexGlyphPadding, TEX_HEIGHT_MAX - atlas->TexGlyphPadding, pack_nodes.Data, pack_nodes.Size);
+    stbrp_init_target(&pack_context, atlas->TexData.TexWidth - atlas->TexGlyphPadding, TEX_HEIGHT_MAX - atlas->TexGlyphPadding, pack_nodes.Data, pack_nodes.Size);
     ImFontAtlasBuildPackCustomRects(atlas, &pack_context);
 
     // 6. Pack each source font. No rendering yet, we are working with rectangles in an infinitely tall texture at this point.
@@ -646,28 +645,17 @@ bool ImFontAtlasBuildWithFreeTypeEx(FT_Library ft_library, ImFontAtlas* atlas, u
         // FIXME: We are not handling packing failure here (would happen if we got off TEX_HEIGHT_MAX or if a single if larger than TexWidth?)
         for (int glyph_i = 0; glyph_i < src_tmp.GlyphsCount; glyph_i++)
             if (src_tmp.Rects[glyph_i].was_packed)
-                atlas->TexHeight = ImMax(atlas->TexHeight, src_tmp.Rects[glyph_i].y + src_tmp.Rects[glyph_i].h);
+                atlas->TexData.TexHeight = ImMax(atlas->TexData.TexHeight, src_tmp.Rects[glyph_i].y + src_tmp.Rects[glyph_i].h);
     }
 
     // 7. Allocate texture
-    atlas->TexHeight = (atlas->Flags & ImFontAtlasFlags_NoPowerOfTwoHeight) ? (atlas->TexHeight + 1) : ImUpperPowerOfTwo(atlas->TexHeight);
-    atlas->TexUvScale = ImVec2(1.0f / atlas->TexWidth, 1.0f / atlas->TexHeight);
-    if (src_load_color)
-    {
-        size_t tex_size = (size_t)atlas->TexWidth * atlas->TexHeight * 4;
-        atlas->TexPixelsRGBA32 = (unsigned int*)IM_ALLOC(tex_size);
-        memset(atlas->TexPixelsRGBA32, 0, tex_size);
-    }
-    else
-    {
-        size_t tex_size = (size_t)atlas->TexWidth * atlas->TexHeight * 1;
-        atlas->TexPixelsAlpha8 = (unsigned char*)IM_ALLOC(tex_size);
-        memset(atlas->TexPixelsAlpha8, 0, tex_size);
-    }
+    atlas->TexData.TexHeight = (atlas->Flags & ImFontAtlasFlags_NoPowerOfTwoHeight) ? (atlas->TexData.TexHeight + 1) : ImUpperPowerOfTwo(atlas->TexData.TexHeight);
+    atlas->TexUvScale = ImVec2(1.0f / atlas->TexData.TexWidth, 1.0f / atlas->TexData.TexHeight);
+    atlas->TexData.AllocatePixels(atlas->TexData.TexWidth, atlas->TexData.TexHeight,
+        src_load_color ? ImTextureFormat_RGBA32 : ImTextureFormat_Alpha8);
 
     // 8. Copy rasterized font characters back into the main texture
     // 9. Setup ImFont and glyphs for runtime
-    bool tex_use_colors = false;
     for (int src_i = 0; src_i < src_tmp_array.Size; src_i++)
     {
         ImFontBuildSrcDataFT& src_tmp = src_tmp_array[src_i];
@@ -706,31 +694,31 @@ bool ImFontAtlasBuildWithFreeTypeEx(FT_Library ft_library, ImFontAtlas* atlas, u
             float y0 = info.OffsetY * src_tmp.Font.InvRasterizationDensity + font_off_y;
             float x1 = x0 + info.Width * src_tmp.Font.InvRasterizationDensity;
             float y1 = y0 + info.Height * src_tmp.Font.InvRasterizationDensity;
-            float u0 = (tx) / (float)atlas->TexWidth;
-            float v0 = (ty) / (float)atlas->TexHeight;
-            float u1 = (tx + info.Width) / (float)atlas->TexWidth;
-            float v1 = (ty + info.Height) / (float)atlas->TexHeight;
+            float u0 = (tx) / (float)atlas->TexData.TexWidth;
+            float v0 = (ty) / (float)atlas->TexData.TexHeight;
+            float u1 = (tx + info.Width) / (float)atlas->TexData.TexWidth;
+            float v1 = (ty + info.Height) / (float)atlas->TexData.TexHeight;
             dst_font->AddGlyph(&cfg, (ImWchar)src_glyph.Codepoint, x0, y0, x1, y1, u0, v0, u1, v1, info.AdvanceX * src_tmp.Font.InvRasterizationDensity);
 
             ImFontGlyph* dst_glyph = &dst_font->Glyphs.back();
             IM_ASSERT(dst_glyph->Codepoint == src_glyph.Codepoint);
             if (src_glyph.Info.IsColored)
-                dst_glyph->Colored = tex_use_colors = true;
+                atlas->TexData.EnsureFormat(ImTextureFormat_RGBA32);
 
             // Blit from temporary buffer to final texture
             size_t blit_src_stride = (size_t)src_glyph.Info.Width;
-            size_t blit_dst_stride = (size_t)atlas->TexWidth;
+            size_t blit_dst_stride = (size_t)atlas->TexData.TexWidth;
             unsigned int* blit_src = src_glyph.BitmapData;
-            if (atlas->TexPixelsAlpha8 != nullptr)
+            if (atlas->TexData.TexFormat == ImTextureFormat_Alpha8)
             {
-                unsigned char* blit_dst = atlas->TexPixelsAlpha8 + (ty * blit_dst_stride) + tx;
+                unsigned char* blit_dst = (unsigned char*)atlas->TexData.TexPixels + (ty * blit_dst_stride) + tx;
                 for (int y = 0; y < info.Height; y++, blit_dst += blit_dst_stride, blit_src += blit_src_stride)
                     for (int x = 0; x < info.Width; x++)
                         blit_dst[x] = (unsigned char)((blit_src[x] >> IM_COL32_A_SHIFT) & 0xFF);
             }
             else
             {
-                unsigned int* blit_dst = atlas->TexPixelsRGBA32 + (ty * blit_dst_stride) + tx;
+                unsigned int* blit_dst = (unsigned int*)atlas->TexData.TexPixels + (ty * blit_dst_stride) + tx;
                 for (int y = 0; y < info.Height; y++, blit_dst += blit_dst_stride, blit_src += blit_src_stride)
                     for (int x = 0; x < info.Width; x++)
                         blit_dst[x] = blit_src[x];
@@ -739,7 +727,6 @@ bool ImFontAtlasBuildWithFreeTypeEx(FT_Library ft_library, ImFontAtlas* atlas, u
 
         src_tmp.Rects = nullptr;
     }
-    atlas->TexPixelsUseColors = tex_use_colors;
 
     // Cleanup
     for (int buf_i = 0; buf_i < buf_bitmap_buffers.Size; buf_i++)

--- a/OptiScaler/menu/menu_base.cpp
+++ b/OptiScaler/menu/menu_base.cpp
@@ -11,6 +11,7 @@ void MenuBase::LoadCustomFonts(ImGuiIO& io, float menuScale)
     atlas->Clear();
     constexpr float fontSize = 14.0f; // just changing this doesn't make other elements scale ideally
 
+    // This automatically becomes the next default font
     ImFontConfig fontConfig;
     //fontConfig.FontBuilderFlags |= ImGuiFreeTypeBuilderFlags_LightHinting;
     font = atlas->AddFontFromMemoryCompressedBase85TTF(hack_compressed_compressed_data_base85, std::round(menuScale * fontSize), &fontConfig);
@@ -37,7 +38,7 @@ void MenuBase::UpdateFonts(ImGuiIO& io, float rasterizerDensity)
 {
     static float lastDensity = 0.0f;
 
-    if (lastDensity != rasterizerDensity)
+    if (lastDensity != rasterizerDensity || io.Fonts->Fonts.empty())
     {
         LoadCustomFonts(io, rasterizerDensity);
         lastDensity = rasterizerDensity;

--- a/OptiScaler/menu/menu_base.cpp
+++ b/OptiScaler/menu/menu_base.cpp
@@ -1,0 +1,45 @@
+#include "font/Hack_Compressed.h"
+#include "imgui/imgui.h"
+#include "imgui/misc/freetype/imgui_freetype.h"
+#include "menu_base.h"
+
+// TODO: maybe a vector of fonts?
+void MenuBase::LoadCustomFonts(ImGuiIO& io, float menuScale)
+{
+    LOG_INFO("Loading fonts with scale of: {}", menuScale);
+    ImFontAtlas* atlas = io.Fonts;
+    atlas->Clear();
+    constexpr float fontSize = 14.0f; // just changing this doesn't make other elements scale ideally
+
+    ImFontConfig fontConfig;
+    //fontConfig.FontBuilderFlags |= ImGuiFreeTypeBuilderFlags_LightHinting;
+    font = atlas->AddFontFromMemoryCompressedBase85TTF(hack_compressed_compressed_data_base85, std::round(menuScale * fontSize), &fontConfig);
+    if (!font)
+    {
+        LOG_ERROR("Couldn't create font");
+        return;
+    }
+
+    ImFontConfig scaledFontConfig;
+    constexpr auto scaledFontScale = 3.0f;
+    //fontConfig.FontBuilderFlags |= ImGuiFreeTypeBuilderFlags_LightHinting;
+    scaledFont = atlas->AddFontFromMemoryCompressedBase85TTF(hack_compressed_compressed_data_base85, std::round(scaledFontScale * menuScale * fontSize), &scaledFontConfig);
+    if (!scaledFont)
+    {
+        LOG_ERROR("Couldn't create scaled font");
+        return;
+    }
+
+    io.Fonts->Build();
+}
+
+void MenuBase::UpdateFonts(ImGuiIO& io, float rasterizerDensity)
+{
+    static float lastDensity = 0.0f;
+
+    if (lastDensity != rasterizerDensity)
+    {
+        LoadCustomFonts(io, rasterizerDensity);
+        lastDensity = rasterizerDensity;
+    }
+}

--- a/OptiScaler/menu/menu_base.h
+++ b/OptiScaler/menu/menu_base.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "pch.h"
+#include "imgui/imgui.h"
+
+class MenuBase
+{
+	static void LoadCustomFonts(ImGuiIO& io, float menuScale);
+public:
+    static void UpdateFonts(ImGuiIO& io, float rasterizerDensity);
+
+	inline static ImFont* font = nullptr;
+	inline static ImFont* scaledFont = nullptr;
+};

--- a/OptiScaler/menu/menu_common.cpp
+++ b/OptiScaler/menu/menu_common.cpp
@@ -2996,7 +2996,7 @@ bool MenuCommon::RenderMenu()
                     if (!ImGui::IsWindowFocused(ImGuiFocusedFlags_AnyWindow))
                         ImGui::SetWindowFocus();
 
-                        if (ImGui::InputScalar("Display Width", ImGuiDataType_U32, &_displayWidth, NULL, NULL, "%u"))
+                    if (ImGui::InputScalar("Display Width", ImGuiDataType_U32, &_displayWidth, NULL, NULL, "%u"))
                     {
                         if (_displayWidth <= 0)
                         {

--- a/OptiScaler/menu/menu_common.cpp
+++ b/OptiScaler/menu/menu_common.cpp
@@ -899,8 +899,6 @@ bool MenuCommon::RenderMenu()
         MenuSizeCheck(io);
         ImGui::NewFrame();
 
-        ImGui::PushFont(MenuBase::font);
-
         State::Instance().frameTimes.pop_front();
         State::Instance().frameTimes.push_back(1000.0 / io.Framerate);
 
@@ -1051,8 +1049,6 @@ bool MenuCommon::RenderMenu()
             ImGui::PopStyleColor(3); // Restore the style
         }
 
-        ImGui::PopFont();
-
         // Get size for postioning
         auto winSize = ImGui::GetWindowSize();
 
@@ -1119,8 +1115,6 @@ bool MenuCommon::RenderMenu()
             style.MouseCursorScale = 1.0f;
             CopyMemory(style.Colors, styleold.Colors, sizeof(style.Colors)); // Restore colors		
         }
-
-        ImGui::PushFont(MenuBase::font);
 
         auto currentFeature = State::Instance().currentFeature;
 
@@ -3114,8 +3108,6 @@ bool MenuCommon::RenderMenu()
                     ImGui::End();
                 }
             }
-
-            ImGui::PopFont();
         }
 
         return true;

--- a/OptiScaler/menu/menu_common.h
+++ b/OptiScaler/menu/menu_common.h
@@ -9,6 +9,8 @@
 #include "imgui/imgui.h"
 #include "imgui/imgui_impl_win32.h"
 
+#include "menu_base.h"
+
 #include <detours/detours.h>
 
 extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
@@ -55,10 +57,6 @@ private:
     inline static bool _dx11Ready = false;
     inline static bool _dx12Ready = false;
     inline static bool _vulkanReady = false;
-
-    // font
-    inline static ImFont* _optiFont = nullptr;
-    inline static ImFont* _scaledOptiFont = nullptr;
 
     inline static void ShowTooltip(const char* tip);
 
@@ -127,7 +125,6 @@ private:
     static void PopulateCombo(std::string name, CustomOptional<uint32_t, B>* value, const char* names[], const std::string desc[], int length);
 
 public:
-
     static void Dx11Inited() { _dx11Ready = true; }
     static void Dx12Inited() { _dx12Ready = true; }
     static void VulkanInited() { _vulkanReady = true; }

--- a/OptiScaler/menu/menu_dx11.cpp
+++ b/OptiScaler/menu/menu_dx11.cpp
@@ -1,4 +1,7 @@
 #include "menu_dx11.h"
+
+#include "Config.h"
+#include "menu_common.h"
 #include "imgui/imgui_impl_dx11.h"
 #include "imgui/imgui_impl_win32.h"
 
@@ -83,7 +86,11 @@ bool Menu_Dx11::Render(ID3D11DeviceContext* pCmdList, ID3D11Resource* outTexture
 
 	CreateRenderTarget(outTexture);
 
-	if (!_dx11Init && ImGui::GetIO().BackendRendererUserData == nullptr)
+	ImGuiIO& io = ImGui::GetIO(); (void)io;
+	io.BackendFlags |= ImGuiBackendFlags_RendererHasTexReload;
+	UpdateFonts(io, Config::Instance()->MenuScale.value_or_default());
+
+	if (!_dx11Init && io.BackendRendererUserData == nullptr)
 		_dx11Init = ImGui_ImplDX11_Init(_device, pCmdList);
 
 	if (!_dx11Init)

--- a/OptiScaler/menu/menu_dx12.cpp
+++ b/OptiScaler/menu/menu_dx12.cpp
@@ -19,6 +19,9 @@ bool Menu_Dx12::Render(ID3D12GraphicsCommandList* pCmdList, ID3D12Resource* outT
 
     frameCounter++;
 
+    //if (!IsVisible())
+    //	return true;
+
     auto outDesc = outTexture->GetDesc();
 
     CreateRenderTarget(outDesc);

--- a/OptiScaler/menu/menu_dx12.cpp
+++ b/OptiScaler/menu/menu_dx12.cpp
@@ -76,8 +76,7 @@ bool Menu_Dx12::Render(ID3D12GraphicsCommandList* pCmdList, ID3D12Resource* outT
         if (!ImGui::GetDrawData())
             return false;
 
-        if (IsVisible()) // Dirty workaround as the menu gets always rendered
-            ImGui_ImplDX12_RenderDrawData(ImGui::GetDrawData(), pCmdList);
+        ImGui_ImplDX12_RenderDrawData(ImGui::GetDrawData(), pCmdList);
 
         outBarrier.Transition.StateBefore = D3D12_RESOURCE_STATE_RENDER_TARGET;
         outBarrier.Transition.StateAfter = D3D12_RESOURCE_STATE_UNORDERED_ACCESS;

--- a/OptiScaler/menu/menu_dx_base.cpp
+++ b/OptiScaler/menu/menu_dx_base.cpp
@@ -5,6 +5,7 @@
 
 #include "menu_common.h"
 #include "menu_dx_base.h"
+
 #include "imgui/imgui_impl_win32.h"
 
 bool MenuDxBase::RenderMenu()
@@ -64,7 +65,7 @@ MenuDxBase::~MenuDxBase()
     MenuCommon::Shutdown();
 }
 
-bool MenuDxBase::IsVisible() const
+bool MenuDxBase::IsVisible()
 {
     return MenuCommon::IsVisible();
 }

--- a/OptiScaler/menu/menu_dx_base.h
+++ b/OptiScaler/menu/menu_dx_base.h
@@ -1,8 +1,9 @@
+#pragma once
 #include <pch.h>
-#include "menu_common.h"
 #include <dxgi.h>
+#include "menu_base.h"
 
-class MenuDxBase
+class MenuDxBase : public MenuBase
 {
 private:
 	HWND _handle = nullptr;
@@ -14,9 +15,9 @@ private:
 
 protected:
 	long frameCounter = 0;
-	bool RenderMenu();
+    static bool RenderMenu();
 
-	static DXGI_FORMAT TranslateTypelessFormats(DXGI_FORMAT format)
+    static DXGI_FORMAT TranslateTypelessFormats(DXGI_FORMAT format)
 	{
 		switch (format) {
 			case DXGI_FORMAT_R32G32B32A32_TYPELESS:
@@ -41,7 +42,7 @@ protected:
 	}
 
 public:
-	bool IsVisible() const;
+    static bool IsVisible();
 	bool IsInited() const { return _baseInit; }
 	int Width() { return _width; }
 	int Height() { return _height; }
@@ -49,8 +50,8 @@ public:
 	int Left() { return _left; }
 	HWND Handle() { return _handle; }
 	bool IsHandleDifferent();
-	void Dx11Ready();
-	void Dx12Ready();
+    static void Dx11Ready();
+    static void Dx12Ready();
 
 	explicit MenuDxBase(HWND handle);
 

--- a/OptiScaler/menu/menu_overlay_base.h
+++ b/OptiScaler/menu/menu_overlay_base.h
@@ -5,7 +5,9 @@
 #include <d3d12.h>
 #include <dxgi1_6.h>
 
-class MenuOverlayBase
+#include "menu_base.h"
+
+class MenuOverlayBase : public MenuBase
 {
 public:
 	static HWND Handle();
@@ -18,7 +20,7 @@ public:
 	static bool IsVisible();
 
 	static void Init(HWND InHandle);
-	static bool RenderMenu();
+    static bool RenderMenu();
 	static void Shutdown();
 	static void HideMenu();
 };

--- a/OptiScaler/menu/menu_overlay_dx.cpp
+++ b/OptiScaler/menu/menu_overlay_dx.cpp
@@ -261,7 +261,11 @@ static void RenderImGui_DX11(IDXGISwapChain* pSwapChain)
 
     LOG_FUNC();
 
-    if (ImGui::GetIO().BackendRendererUserData == nullptr)
+    ImGuiIO& io = ImGui::GetIO(); (void)io;
+    io.BackendFlags |= ImGuiBackendFlags_RendererHasTexReload;
+    MenuOverlayBase::UpdateFonts(io, Config::Instance()->MenuScale.value_or_default());
+
+    if (io.BackendRendererUserData == nullptr)
     {
         if (pSwapChain->GetDevice(IID_PPV_ARGS(&g_pd3dDevice)) == S_OK)
         {
@@ -327,8 +331,12 @@ static void RenderImGui_DX12(IDXGISwapChain* pSwapChainPlain)
     // Get device from swapchain
     ID3D12Device* device = g_pd3dDeviceParam;
 
+    ImGuiIO& io = ImGui::GetIO(); (void)io;
+    io.BackendFlags |= ImGuiBackendFlags_RendererHasTexReload;
+    MenuOverlayBase::UpdateFonts(io, Config::Instance()->MenuScale.value_or_default());
+
     // Generate ImGui resources
-    if (!ImGui::GetIO().BackendRendererUserData && currentSCCommandQueue != nullptr)
+    if (!io.BackendRendererUserData && currentSCCommandQueue != nullptr)
     {
         LOG_DEBUG("ImGui::GetIO().BackendRendererUserData == nullptr");
 
@@ -439,6 +447,9 @@ static void RenderImGui_DX12(IDXGISwapChain* pSwapChainPlain)
             _showRenderImGuiDebugOnce = true;
 
             ImGui_ImplDX12_NewFrame();
+
+            if (io.Fonts->IsDirty())
+                ImGui_ImplDX12_UpdateFontsTexture();
 
             if (MenuOverlayBase::RenderMenu())
             {

--- a/OptiScaler/menu/menu_overlay_vk.cpp
+++ b/OptiScaler/menu/menu_overlay_vk.cpp
@@ -342,8 +342,8 @@ static void CreateVulkanObjects(VkDevice device, VkPhysicalDevice pd, VkInstance
             return;
         }
 
-        initResult = ImGui_ImplVulkan_CreateFontsTexture();
-        LOG_DEBUG("ImGui_ImplVulkan_CreateFontsTexture result: {}", initResult);
+        initResult = ImGui_ImplVulkan_UpdateFontsTexture();
+        LOG_DEBUG("ImGui_ImplVulkan_UpdateFontsTexture result: {}", initResult);
 
         VkSubmitInfo end_info = { };
         end_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
@@ -463,8 +463,15 @@ bool MenuOverlayVk::QueuePresent(VkQueue queue, VkPresentInfoKHR* pPresentInfo)
     std::lock_guard<std::mutex> lock(_vkPresentMutex);
     LOG_DEBUG("rendering menu, swapchain count: {0}", pPresentInfo->swapchainCount);
 
+    ImGuiIO& io = ImGui::GetIO(); (void)io;
+    io.BackendFlags |= ImGuiBackendFlags_RendererHasTexReload;
+    MenuOverlayBase::UpdateFonts(io, Config::Instance()->MenuScale.value_or_default());
+
     {
         ImGui_ImplVulkan_NewFrame();
+
+        if (io.Fonts->IsDirty())
+            ImGui_ImplVulkan_UpdateFontsTexture();
 
         if (MenuOverlayBase::RenderMenu())
         {

--- a/OptiScaler/upscalers/IFeature_Dx12.cpp
+++ b/OptiScaler/upscalers/IFeature_Dx12.cpp
@@ -1,6 +1,8 @@
 #include "IFeature_Dx12.h"
 #include <pch.h>
 
+#include "State.h"
+
 void IFeature_Dx12::ResourceBarrier(ID3D12GraphicsCommandList* InCommandList, ID3D12Resource* InResource, D3D12_RESOURCE_STATES InBeforeState, D3D12_RESOURCE_STATES InAfterState) const
 {
 	D3D12_RESOURCE_BARRIER barrier = {};


### PR DESCRIPTION
Uses https://github.com/ocornut/imgui/pull/3761

This gives us the ability to get the correctly sampled font for the currently selected scale which generally looks sharper.

Creates two scaled fonts: 1 * scale and 3 * scale. Some system for requesting differently sized fonts can be implemented in the future. 
Uses a base class that get inherited by dx base and overlay base which don't feel quite right with the existence of menu common so I'm open to changing that if need be.