### PR TITLE
Fix upscaler not saving correctly

### DIFF
--- a/OptiScaler/menu/menu_common.cpp
+++ b/OptiScaler/menu/menu_common.cpp
@@ -651,7 +651,7 @@ void MenuCommon::AddVulkanBackends(std::string* code, std::string* name)
     }
 }
 
-template <bool B>
+template <HasDefaultValue B>
 void MenuCommon::AddResourceBarrier(std::string name, CustomOptional<int32_t, B>* value)
 {
     const char* states[] = { "AUTO", "COMMON", "VERTEX_AND_CONSTANT_BUFFER", "INDEX_BUFFER", "RENDER_TARGET", "UNORDERED_ACCESS", "DEPTH_WRITE",
@@ -691,7 +691,7 @@ void MenuCommon::AddResourceBarrier(std::string name, CustomOptional<int32_t, B>
     }
 }
 
-template <bool B>
+template <HasDefaultValue B>
 void MenuCommon::AddRenderPreset(std::string name, CustomOptional<uint32_t, B>* value)
 {
     const char* presets[] = { "DEFAULT", "PRESET A", "PRESET B", "PRESET C", "PRESET D", "PRESET E", "PRESET F", "PRESET G",
@@ -718,7 +718,7 @@ void MenuCommon::AddRenderPreset(std::string name, CustomOptional<uint32_t, B>* 
     PopulateCombo(name, value, presets, presetsDesc, 16);
 }
 
-template <bool B>
+template <HasDefaultValue B>
 void MenuCommon::PopulateCombo(std::string name, CustomOptional<uint32_t, B>* value, const char* names[], const std::string desc[], int length) {
     int selected = value->value_or(0);
 

--- a/OptiScaler/menu/menu_common.h
+++ b/OptiScaler/menu/menu_common.h
@@ -117,11 +117,11 @@ private:
     static void AddDx11Backends(std::string* code, std::string* name);
     static void AddDx12Backends(std::string* code, std::string* name);
     static void AddVulkanBackends(std::string* code, std::string* name);
-    template <bool B>
+    template <HasDefaultValue B>
     static void AddResourceBarrier(std::string name, CustomOptional<int32_t, B>* value);
-    template <bool B>
+    template <HasDefaultValue B>
     static void AddRenderPreset(std::string name, CustomOptional<uint32_t, B>* value);
-    template <bool B>
+    template <HasDefaultValue B>
     static void PopulateCombo(std::string name, CustomOptional<uint32_t, B>* value, const char* names[], const std::string desc[], int length);
 
 public:


### PR DESCRIPTION
Fixes xess selection not being saved on dlss-capable systems.

Keeps the option of using value_or_default() with settings that might be system dependent. 