### PR TITLE
Fix reading of OTA dlss/dlssd versions

### DIFF
--- a/OptiScaler/OptiScaler.vcxproj
+++ b/OptiScaler/OptiScaler.vcxproj
@@ -196,7 +196,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
     <Link>
@@ -226,7 +226,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <FloatingPointModel>Fast</FloatingPointModel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
@@ -270,7 +270,7 @@ copy NUL "$(SolutionDir)x64\Release\a\!! EXTRACT ALL FILES TO GAME FOLDER !!" /Y
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <FloatingPointModel>Fast</FloatingPointModel>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>

--- a/OptiScaler/State.h
+++ b/OptiScaler/State.h
@@ -69,6 +69,10 @@ public:
 	NVSDK_NGX_EngineType NVNGX_Engine = NVSDK_NGX_ENGINE_TYPE_CUSTOM;
 	std::string NVNGX_EngineVersion;
 
+	// NGX OTA
+	std::string NGX_OTA_Dlss;
+	std::string NGX_OTA_Dlssd;
+
 	API api = API::NotSelected;
 	API swapchainApi = API::NotSelected;
 

--- a/OptiScaler/upscalers/dlss/DLSSFeature.cpp
+++ b/OptiScaler/upscalers/dlss/DLSSFeature.cpp
@@ -284,13 +284,18 @@ void DLSSFeature::ReadVersion()
             _GetSnippetVersion = (PFN_NVSDK_NGX_GetSnippetVersion)DetourFindFunction(dlssPath.filename().string().c_str(), "NVSDK_NGX_GetSnippetVersion");
     }
 
+    if (_GetSnippetVersion == nullptr && !State::Instance().NGX_OTA_Dlss.empty())
+    {
+        _GetSnippetVersion = (PFN_NVSDK_NGX_GetSnippetVersion)DetourFindFunction(State::Instance().NGX_OTA_Dlss.c_str(), "NVSDK_NGX_GetSnippetVersion");
+    }
+
     if (_GetSnippetVersion != nullptr)
     {
         LOG_TRACE("_GetSnippetVersion ptr: {0:X}", (ULONG64)_GetSnippetVersion);
 
         auto result = _GetSnippetVersion();
 
-        _version.major = (result & 0x00FF0000) / 0x00010000;
+        _version.major = (result & 0xFFFF0000) / 0x00010000;
         _version.minor = (result & 0x0000FF00) / 0x00000100;
         _version.patch = result & 0x000000FF / 0x00000001;
 

--- a/OptiScaler/upscalers/dlssd/DLSSDFeature.cpp
+++ b/OptiScaler/upscalers/dlssd/DLSSDFeature.cpp
@@ -274,13 +274,18 @@ void DLSSDFeature::ReadVersion()
 
     _GetSnippetVersion = (PFN_NVSDK_NGX_GetSnippetVersion)DetourFindFunction("nvngx_dlssd.dll", "NVSDK_NGX_GetSnippetVersion");
 
+    if (_GetSnippetVersion == nullptr && !State::Instance().NGX_OTA_Dlssd.empty())
+    {
+        _GetSnippetVersion = (PFN_NVSDK_NGX_GetSnippetVersion)DetourFindFunction(State::Instance().NGX_OTA_Dlssd.c_str(), "NVSDK_NGX_GetSnippetVersion");
+    }
+
     if (_GetSnippetVersion != nullptr)
     {
         LOG_TRACE("_GetSnippetVersion ptr: {0:X}", (ULONG64)_GetSnippetVersion);
 
         auto result = _GetSnippetVersion();
 
-        _version.major = (result & 0x00FF0000) / 0x00010000;
+        _version.major = (result & 0xFFFF0000) / 0x00010000;
         _version.minor = (result & 0x0000FF00) / 0x00000100;
         _version.patch = result & 0x000000FF / 0x00000001;
 


### PR DESCRIPTION
Fixes OTA versions, displayed as 0.0.0 previously and longer DLSS versions which caused 310 to be shown as 54.
![image](https://github.com/user-attachments/assets/a0f7fb56-bba1-4c64-aa1d-e6e467ec3531)
