### PR TITLE
fix double quoting in OptiScaler Setup.bat

### DIFF
--- a/OptiScaler Setup.bat
+++ b/OptiScaler Setup.bat
@@ -161,7 +161,7 @@ if "!overwriteChoice!"=="y" (
 )
 
 echo Renaming OptiScaler file to %selectedFilename%...
-rename "%optiScalerFile%" "%selectedFilename%"
+rename "%optiScalerFile%" %selectedFilename%
 if errorlevel 1 (
     echo.
     echo ERROR: Failed to rename OptiScaler file to %selectedFilename%.


### PR DESCRIPTION
i immediately ran into this double quoting issue when running `OptiScaler Setup.bat` in wine.
not sure if it is a problem on windows

`selectedFilename` is always in double quotes already, so no need to quote it in the `rename` command