### PR TITLE
Better deal with dxvk-nvapi

### DIFF
--- a/OptiScaler/dllmain.h
+++ b/OptiScaler/dllmain.h
@@ -2248,37 +2248,61 @@ HRESULT WINAPI detEnumAdapters(IDXGIFactory* This, UINT Adapter, IDXGIAdapter** 
 HRESULT _CreateDXGIFactory(REFIID riid, IDXGIFactory** ppFactory)
 {
     State::Instance().skipDxgiLoadChecks = true;
-    HRESULT result = dxgi.CreateDxgiFactory(riid, ppFactory);
-    State::Instance().skipDxgiLoadChecks = false;
+    if (dxgi.CreateDxgiFactory) {
+        HRESULT result = dxgi.CreateDxgiFactory(riid, ppFactory);
+        State::Instance().skipDxgiLoadChecks = false;
 
-    if (result == S_OK)
-        AttachToFactory(*ppFactory);
+        if (result == S_OK)
+            AttachToFactory(*ppFactory);
 
-    return result;
+        return result;
+    }
+    else 
+    {
+        LOG_ERROR("CreateDxgiFactory is NULL");
+        State::Instance().skipDxgiLoadChecks = false;
+        return DXGI_ERROR_INVALID_CALL;
+    }
 }
 
 HRESULT _CreateDXGIFactory1(REFIID riid, IDXGIFactory1** ppFactory)
 {
     State::Instance().skipDxgiLoadChecks = true;
-    HRESULT result = dxgi.CreateDxgiFactory1(riid, ppFactory);
-    State::Instance().skipDxgiLoadChecks = false;
+    if (dxgi.CreateDxgiFactory1) {
+        HRESULT result = dxgi.CreateDxgiFactory1(riid, ppFactory);
+        State::Instance().skipDxgiLoadChecks = false;
 
-    if (result == S_OK)
-        AttachToFactory(*ppFactory);
+        if (result == S_OK)
+            AttachToFactory(*ppFactory);
 
-    return result;
+        return result;
+    }
+    else 
+    {
+        LOG_ERROR("CreateDxgiFactory1 is NULL");
+        State::Instance().skipDxgiLoadChecks = false;
+        return DXGI_ERROR_INVALID_CALL;
+    }
 }
 
 HRESULT _CreateDXGIFactory2(UINT Flags, REFIID riid, IDXGIFactory2** ppFactory)
 {
     State::Instance().skipDxgiLoadChecks = true;
-    HRESULT result = dxgi.CreateDxgiFactory2(Flags, riid, ppFactory);
-    State::Instance().skipDxgiLoadChecks = false;
+    if (dxgi.CreateDxgiFactory2) {
+        HRESULT result = dxgi.CreateDxgiFactory2(Flags, riid, ppFactory);
+        State::Instance().skipDxgiLoadChecks = false;
 
-    if (result == S_OK)
-        AttachToFactory(*ppFactory);
+        if (result == S_OK)
+            AttachToFactory(*ppFactory);
 
-    return result;
+        return result;
+    }
+    else
+    {
+        LOG_ERROR("CreateDxgiFactory2 is NULL");
+        State::Instance().skipDxgiLoadChecks = false;
+        return DXGI_ERROR_INVALID_CALL;
+    }
 }
 
 HRESULT _DXGIDeclareAdapterRemovalSupport()

--- a/OptiScaler/nvapi/NvApiHooks.cpp
+++ b/OptiScaler/nvapi/NvApiHooks.cpp
@@ -84,12 +84,12 @@ void* __stdcall NvApiHooks::hkNvAPI_QueryInterface(unsigned int InterfaceId)
     {
         if (InterfaceId == GET_ID(NvAPI_GPU_GetArchInfo) && !State::Instance().enablerAvailable)
         {
-            o_NvAPI_GPU_GetArchInfo = static_cast<decltype(&NvAPI_GPU_GetArchInfo)>(functionPointer);
+            o_NvAPI_GPU_GetArchInfo = reinterpret_cast<decltype(&NvAPI_GPU_GetArchInfo)>(functionPointer);
             return &hkNvAPI_GPU_GetArchInfo;
         }
         if (InterfaceId == GET_ID(NvAPI_DRS_GetSetting))
         {
-            o_NvAPI_DRS_GetSetting = static_cast<decltype(&NvAPI_DRS_GetSetting)>(functionPointer);
+            o_NvAPI_DRS_GetSetting = reinterpret_cast<decltype(&NvAPI_DRS_GetSetting)>(functionPointer);
             return &hkNvAPI_DRS_GetSetting;
         }
     }

--- a/OptiScaler/nvapi/NvApiTypes.h
+++ b/OptiScaler/nvapi/NvApiTypes.h
@@ -6,6 +6,7 @@
 #include <nvapi.h>
 
 #define GET_ID(name) NvApiTypes::Instance().getId(#name)
+#define GET_INTERFACE(name, queryInterface) reinterpret_cast<decltype(&name)>(queryInterface(GET_ID(name)))
 
 typedef void* (__stdcall* PFN_NvApi_QueryInterface)(unsigned int InterfaceId);
 typedef NvAPI_Status(__stdcall* PFN_Fake_InformFGState)(bool fg_state);

--- a/OptiScaler/nvapi/ReflexHooks.cpp
+++ b/OptiScaler/nvapi/ReflexHooks.cpp
@@ -91,11 +91,11 @@ void ReflexHooks::hookReflex(PFN_NvApi_QueryInterface& queryInterface) {
 #endif
 
     if (!_inited) {
-        o_NvAPI_D3D_SetSleepMode = static_cast<decltype(&NvAPI_D3D_SetSleepMode)>(queryInterface(GET_ID(NvAPI_D3D_SetSleepMode)));
-        o_NvAPI_D3D_Sleep = static_cast<decltype(&NvAPI_D3D_Sleep)>(queryInterface(GET_ID(NvAPI_D3D_Sleep)));
-        o_NvAPI_D3D_GetLatency = static_cast<decltype(&NvAPI_D3D_GetLatency)>(queryInterface(GET_ID(NvAPI_D3D_GetLatency)));
-        o_NvAPI_D3D_SetLatencyMarker = static_cast<decltype(&NvAPI_D3D_SetLatencyMarker)>(queryInterface(GET_ID(NvAPI_D3D_SetLatencyMarker)));
-        o_NvAPI_D3D12_SetAsyncFrameMarker = static_cast<decltype(&NvAPI_D3D12_SetAsyncFrameMarker)>(queryInterface(GET_ID(NvAPI_D3D12_SetAsyncFrameMarker)));
+        o_NvAPI_D3D_SetSleepMode = GET_INTERFACE(NvAPI_D3D_SetSleepMode, queryInterface);
+        o_NvAPI_D3D_Sleep = GET_INTERFACE(NvAPI_D3D_Sleep, queryInterface);
+        o_NvAPI_D3D_GetLatency = GET_INTERFACE(NvAPI_D3D_GetLatency, queryInterface);
+        o_NvAPI_D3D_SetLatencyMarker = GET_INTERFACE(NvAPI_D3D_SetLatencyMarker, queryInterface);
+        o_NvAPI_D3D12_SetAsyncFrameMarker = GET_INTERFACE(NvAPI_D3D12_SetAsyncFrameMarker, queryInterface);
 
         _inited = o_NvAPI_D3D_SetSleepMode && o_NvAPI_D3D_Sleep && o_NvAPI_D3D_GetLatency && o_NvAPI_D3D_SetLatencyMarker && o_NvAPI_D3D12_SetAsyncFrameMarker;
 


### PR DESCRIPTION
Unlike proper nvapi, dxvk-nvapi calls CreateDxgiFactory inside the init call which means we can't call it. GetInterfaceVersionString in dxvk-nvapi can be called without having nvapi inited so use that to identify whether we are using dxvk-nvapi and use EnumDisplayDevices to get GPU vendor instead.