### PR TITLE
Allow for reinit with multiple upscalers active at the same time

### DIFF
--- a/OptiScaler/OptiScaler.vcxproj
+++ b/OptiScaler/OptiScaler.vcxproj
@@ -296,6 +296,7 @@ copy NUL "$(SolutionDir)x64\Release\a\!! EXTRACT ALL FILES TO GAME FOLDER !!" /Y
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="inputs\FfxApi_Vk.h" />
+    <ClInclude Include="inputs\NVNGX_DLSS.h" />
     <ClInclude Include="menu\font\Hack_Compressed.h" />
     <ClInclude Include="menu\menu_base.h" />
     <ClInclude Include="misc\FrameLimit.h" />

--- a/OptiScaler/OptiScaler.vcxproj.filters
+++ b/OptiScaler/OptiScaler.vcxproj.filters
@@ -383,6 +383,9 @@
     <ClInclude Include="FSR4Upgrade.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="inputs\NVNGX_DLSS.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Config.cpp">

--- a/OptiScaler/State.h
+++ b/OptiScaler/State.h
@@ -5,6 +5,7 @@
 
 #include <deque>
 #include <vulkan/vulkan.h>
+#include <ankerl/unordered_dense.h>
 
 typedef enum API
 {
@@ -94,7 +95,7 @@ public:
 	bool reflexShowWarning = false;
 
 	// for realtime changes
-	bool changeBackend = false;
+	ankerl::unordered_dense::map <unsigned int, bool> changeBackend;
 	std::string newBackend = "";
 
 	// XeSS debug stuff

--- a/OptiScaler/inputs/FSR2_Dx12.cpp
+++ b/OptiScaler/inputs/FSR2_Dx12.cpp
@@ -681,7 +681,7 @@ static Fsr212::FfxErrorCode ffxFsr20ContextDispatch_Dx12(Fsr212::FfxFsr2Context*
 
     // HACK, DLSS thinks it's using dynamic res here and errors out when changing quality
     if (evalResult == NVSDK_NGX_Result_Fail && State::Instance().currentFeature->Name() == "DLSS")
-        State::Instance().changeBackend = true;
+        State::Instance().changeBackend[handle->Id] = true;
 
     LOG_ERROR("evalResult: {:X}", (UINT)evalResult);
     return Fsr212::FFX_ERROR_BACKEND_API_ERROR;

--- a/OptiScaler/inputs/FfxApi_Dx12.cpp
+++ b/OptiScaler/inputs/FfxApi_Dx12.cpp
@@ -353,9 +353,10 @@ ffxReturnCode_t ffxDispatch_Dx12(ffxContext* context, ffxDispatchDescHeader* des
     params->Set(NVSDK_NGX_Parameter_Height, dispatchDesc->renderSize.height);
 
     if (dispatchDesc->upscaleSize.width != 0)
-        //params->Set(NVSDK_NGX_Parameter_OutWidth, dispatchDesc->upscaleSize.width);
-    if (dispatchDesc->upscaleSize.height != 0) {
-        //params->Set(NVSDK_NGX_Parameter_OutHeight, dispatchDesc->upscaleSize.height);
+        params->Set(NVSDK_NGX_Parameter_OutWidth, dispatchDesc->upscaleSize.width);
+
+    if (dispatchDesc->upscaleSize.height != 0)
+        params->Set(NVSDK_NGX_Parameter_OutHeight, dispatchDesc->upscaleSize.height);
 
     params->Set(NVSDK_NGX_Parameter_DLSS_Render_Subrect_Dimensions_Width, dispatchDesc->renderSize.width);
     params->Set(NVSDK_NGX_Parameter_DLSS_Render_Subrect_Dimensions_Height, dispatchDesc->renderSize.height);

--- a/OptiScaler/inputs/FfxApi_Dx12.cpp
+++ b/OptiScaler/inputs/FfxApi_Dx12.cpp
@@ -45,19 +45,16 @@ static bool CreateDLSSContext(ffxContext handle, const ffxDispatchDescUpscale* p
     if ((initParams->flags & FFX_UPSCALE_ENABLE_DISPLAY_RESOLUTION_MOTION_VECTORS) == 0)
         initFlags |= NVSDK_NGX_DLSS_Feature_Flags_MVLowRes;
 
-    auto outWidth = pExecParams->upscaleSize.width != 0 ? pExecParams->upscaleSize.width : initParams->maxUpscaleSize.width;
-    auto outHeight = pExecParams->upscaleSize.height != 0 ? pExecParams->upscaleSize.height : initParams->maxUpscaleSize.height;
-
     params->Set(NVSDK_NGX_Parameter_DLSS_Feature_Create_Flags, initFlags);
 
     params->Set(NVSDK_NGX_Parameter_Width, pExecParams->renderSize.width);
     params->Set(NVSDK_NGX_Parameter_Height, pExecParams->renderSize.height);
-    params->Set(NVSDK_NGX_Parameter_OutWidth, outWidth);
-    params->Set(NVSDK_NGX_Parameter_OutHeight, outHeight);
+    params->Set(NVSDK_NGX_Parameter_OutWidth, initParams->maxUpscaleSize.width);
+    params->Set(NVSDK_NGX_Parameter_OutHeight, initParams->maxUpscaleSize.height);
 
-    auto ratio = (float)outWidth / (float)pExecParams->renderSize.width;
+    auto ratio = (float)initParams->maxUpscaleSize.width / (float)pExecParams->renderSize.width;
 
-    LOG_INFO("renderWidth: {}, maxWidth: {}, ratio: {}", pExecParams->renderSize.width, outWidth, ratio);
+    LOG_INFO("renderWidth: {}, maxWidth: {}, ratio: {}", pExecParams->renderSize.width, initParams->maxUpscaleSize.width, ratio);
 
     if (ratio <= 3.0)
         params->Set(NVSDK_NGX_Parameter_PerfQualityValue, NVSDK_NGX_PerfQuality_Value_UltraPerformance);

--- a/OptiScaler/inputs/FfxApi_Dx12.cpp
+++ b/OptiScaler/inputs/FfxApi_Dx12.cpp
@@ -348,13 +348,6 @@ ffxReturnCode_t ffxDispatch_Dx12(ffxContext* context, ffxDispatchDescHeader* des
     params->Set(NVSDK_NGX_Parameter_Reset, dispatchDesc->reset ? 1 : 0);
     params->Set(NVSDK_NGX_Parameter_Width, dispatchDesc->renderSize.width);
     params->Set(NVSDK_NGX_Parameter_Height, dispatchDesc->renderSize.height);
-
-    if (dispatchDesc->upscaleSize.width != 0)
-        params->Set(NVSDK_NGX_Parameter_OutWidth, dispatchDesc->upscaleSize.width);
-
-    if (dispatchDesc->upscaleSize.height != 0)
-        params->Set(NVSDK_NGX_Parameter_OutHeight, dispatchDesc->upscaleSize.height);
-
     params->Set(NVSDK_NGX_Parameter_DLSS_Render_Subrect_Dimensions_Width, dispatchDesc->renderSize.width);
     params->Set(NVSDK_NGX_Parameter_DLSS_Render_Subrect_Dimensions_Height, dispatchDesc->renderSize.height);
     params->Set(NVSDK_NGX_Parameter_Depth, dispatchDesc->depth.resource);

--- a/OptiScaler/inputs/FfxApi_Dx12.cpp
+++ b/OptiScaler/inputs/FfxApi_Dx12.cpp
@@ -45,16 +45,19 @@ static bool CreateDLSSContext(ffxContext handle, const ffxDispatchDescUpscale* p
     if ((initParams->flags & FFX_UPSCALE_ENABLE_DISPLAY_RESOLUTION_MOTION_VECTORS) == 0)
         initFlags |= NVSDK_NGX_DLSS_Feature_Flags_MVLowRes;
 
+    auto outWidth = pExecParams->upscaleSize.width != 0 ? pExecParams->upscaleSize.width : initParams->maxUpscaleSize.width;
+    auto outHeight = pExecParams->upscaleSize.height != 0 ? pExecParams->upscaleSize.height : initParams->maxUpscaleSize.height;
+
     params->Set(NVSDK_NGX_Parameter_DLSS_Feature_Create_Flags, initFlags);
 
     params->Set(NVSDK_NGX_Parameter_Width, pExecParams->renderSize.width);
     params->Set(NVSDK_NGX_Parameter_Height, pExecParams->renderSize.height);
-    params->Set(NVSDK_NGX_Parameter_OutWidth, initParams->maxUpscaleSize.width);
-    params->Set(NVSDK_NGX_Parameter_OutHeight, initParams->maxUpscaleSize.height);
+    params->Set(NVSDK_NGX_Parameter_OutWidth, outWidth);
+    params->Set(NVSDK_NGX_Parameter_OutHeight, outHeight);
 
-    auto ratio = (float)initParams->maxUpscaleSize.width / (float)pExecParams->renderSize.width;
+    auto ratio = (float)outWidth / (float)pExecParams->renderSize.width;
 
-    LOG_INFO("renderWidth: {}, maxWidth: {}, ratio: {}", pExecParams->renderSize.width, initParams->maxUpscaleSize.width, ratio);
+    LOG_INFO("renderWidth: {}, maxWidth: {}, ratio: {}", pExecParams->renderSize.width, outWidth, ratio);
 
     if (ratio <= 3.0)
         params->Set(NVSDK_NGX_Parameter_PerfQualityValue, NVSDK_NGX_PerfQuality_Value_UltraPerformance);
@@ -348,6 +351,12 @@ ffxReturnCode_t ffxDispatch_Dx12(ffxContext* context, ffxDispatchDescHeader* des
     params->Set(NVSDK_NGX_Parameter_Reset, dispatchDesc->reset ? 1 : 0);
     params->Set(NVSDK_NGX_Parameter_Width, dispatchDesc->renderSize.width);
     params->Set(NVSDK_NGX_Parameter_Height, dispatchDesc->renderSize.height);
+
+    if (dispatchDesc->upscaleSize.width != 0)
+        //params->Set(NVSDK_NGX_Parameter_OutWidth, dispatchDesc->upscaleSize.width);
+    if (dispatchDesc->upscaleSize.height != 0) {
+        //params->Set(NVSDK_NGX_Parameter_OutHeight, dispatchDesc->upscaleSize.height);
+
     params->Set(NVSDK_NGX_Parameter_DLSS_Render_Subrect_Dimensions_Width, dispatchDesc->renderSize.width);
     params->Set(NVSDK_NGX_Parameter_DLSS_Render_Subrect_Dimensions_Height, dispatchDesc->renderSize.height);
     params->Set(NVSDK_NGX_Parameter_Depth, dispatchDesc->depth.resource);

--- a/OptiScaler/inputs/NVNGX_DLSS.h
+++ b/OptiScaler/inputs/NVNGX_DLSS.h
@@ -1,0 +1,8 @@
+#pragma once
+
+template <typename FeatureType>
+struct ContextData {
+    std::unique_ptr<FeatureType> feature;
+    NVSDK_NGX_Parameter* createParams = nullptr;
+    int changeBackendCounter = 0;
+};

--- a/OptiScaler/inputs/NVNGX_DLSS_Dx11.cpp
+++ b/OptiScaler/inputs/NVNGX_DLSS_Dx11.cpp
@@ -508,7 +508,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_CreateFeature(ID3D11DeviceContext
     LOG_ERROR("CreateFeature failed");
 
     State::Instance().newBackend = "fsr22";
-    State::Instance().changeBackend = true;
+    State::Instance().changeBackend[handleId] = true;
 
     return NVSDK_NGX_Result_Success;
 }
@@ -652,7 +652,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_EvaluateFeature(ID3D11DeviceConte
 
     IFeature_Dx11* deviceContext = nullptr;
 
-    if (State::Instance().changeBackend)
+    if (State::Instance().changeBackend[handleId])
     {
         if (State::Instance().newBackend == "" || (!Config::Instance()->DLSSEnabled.value_or_default() && State::Instance().newBackend == "dlss"))
             State::Instance().newBackend = Config::Instance()->Dx11Upscaler.value_or_default();
@@ -694,7 +694,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_EvaluateFeature(ID3D11DeviceConte
                 LOG_ERROR("can't find handle {0} in Dx11Contexts!", handleId);
 
                 State::Instance().newBackend = "";
-                State::Instance().changeBackend = false;
+                State::Instance().changeBackend[handleId] = false;
 
                 if (createParams != nullptr)
                 {
@@ -795,12 +795,12 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_EvaluateFeature(ID3D11DeviceConte
                 if (State::Instance().newBackend != "dlssd")
                 {
                     State::Instance().newBackend = "fsr22";
-                    State::Instance().changeBackend = true;
+                    State::Instance().changeBackend[handleId] = true;
                 }
                 else
                 {
                     State::Instance().newBackend = "";
-                    State::Instance().changeBackend = false;
+                    State::Instance().changeBackend[handleId] = false;
                     return NVSDK_NGX_Result_Fail;
                 }
             }
@@ -809,7 +809,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_EvaluateFeature(ID3D11DeviceConte
                 LOG_INFO("init successful for {0}, upscaler changed", State::Instance().newBackend);
 
                 State::Instance().newBackend = "";
-                State::Instance().changeBackend = false;
+                State::Instance().changeBackend[handleId] = false;
                 evalCounter = 0;
             }
 
@@ -848,7 +848,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_EvaluateFeature(ID3D11DeviceConte
     if (!deviceContext->Evaluate(InDevCtx, InParameters) && !deviceContext->IsInited() && (deviceContext->Name() == "XeSS" || deviceContext->Name() == "DLSS" || deviceContext->Name() == "FSR3 w/Dx12"))
     {
         State::Instance().newBackend = "fsr22";
-        State::Instance().changeBackend = true;
+        State::Instance().changeBackend[handleId] = true;
     }
 
     InDevCtx->End(HooksDx::endQueries[nextFrameIndex]);

--- a/OptiScaler/inputs/NVNGX_DLSS_Dx11.cpp
+++ b/OptiScaler/inputs/NVNGX_DLSS_Dx11.cpp
@@ -5,6 +5,7 @@
 
 #include "NVNGX_Parameter.h"
 #include "proxies/NVNGX_Proxy.h"
+#include "NVNGX_DLSS.h"
 
 #include "upscalers/dlss/DLSSFeature_Dx11.h"
 #include "upscalers/dlssd/DLSSDFeature_Dx11.h"
@@ -15,15 +16,13 @@
 #include "upscalers/fsr31/FSR31Feature_Dx11On12.h"
 #include "upscalers/xess/XeSSFeature_Dx11.h"
 
-#include <ankerl/unordered_dense.h>
-
 #include "hooks/HooksDx.h"
+
+#include <ankerl/unordered_dense.h>
 
 
 inline ID3D11Device* D3D11Device = nullptr;
-static inline ankerl::unordered_dense::map <unsigned int, std::unique_ptr<IFeature_Dx11>> Dx11Contexts;
-static ankerl::unordered_dense::map <unsigned int, NVSDK_NGX_Parameter*> createParams;
-static ankerl::unordered_dense::map <unsigned int, int> changeBackendCounter;
+static ankerl::unordered_dense::map<unsigned int, ContextData<IFeature_Dx11>> Dx11Contexts;
 static inline int evalCounter = 0;
 static inline bool shutdown = false;
 
@@ -194,8 +193,8 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_Shutdown()
 
     for (auto const& [key, val] : Dx11Contexts)
     {
-        if (val)
-            NVSDK_NGX_D3D11_ReleaseFeature(val->Handle());
+        if (val.feature)
+            NVSDK_NGX_D3D11_ReleaseFeature(val.feature->Handle());
     }
 
     Dx11Contexts.clear();
@@ -382,16 +381,17 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_CreateFeature(ID3D11DeviceContext
 
         if (Config::Instance()->Dx11Upscaler.value_or(defaultUpscaler) == "xess")
         {
-            Dx11Contexts[handleId] = std::make_unique<XeSSFeatureDx11>(handleId, InParameters);
+            Dx11Contexts[handleId].feature = std::make_unique<XeSSFeatureDx11>(handleId, InParameters);
 
 
-            if (!Dx11Contexts[handleId]->ModuleLoaded())
+            if (!Dx11Contexts[handleId].feature->ModuleLoaded())
             {
                 LOG_ERROR("can't create new XeSS with Dx12 feature, Fallback to FSR2.2!");
 
-                Dx11Contexts[handleId].reset();
-                auto it = std::find_if(Dx11Contexts.begin(), Dx11Contexts.end(), [&handleId](const auto& p) { return p.first == handleId; });
-                Dx11Contexts.erase(it);
+                Dx11Contexts[handleId].feature.reset();
+                Dx11Contexts[handleId].feature = nullptr;
+                //auto it = std::find_if(Dx11Contexts.begin(), Dx11Contexts.end(), [&handleId](const auto& p) { return p.first == handleId; });
+                //Dx11Contexts.erase(it);
 
                 Config::Instance()->Dx11Upscaler = "fsr22";
             }
@@ -405,15 +405,16 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_CreateFeature(ID3D11DeviceContext
         {
             if (Config::Instance()->DLSSEnabled.value_or_default())
             {
-                Dx11Contexts[handleId] = std::make_unique<DLSSFeatureDx11>(handleId, InParameters);
+                Dx11Contexts[handleId].feature = std::make_unique<DLSSFeatureDx11>(handleId, InParameters);
 
-                if (!Dx11Contexts[handleId]->ModuleLoaded())
+                if (!Dx11Contexts[handleId].feature->ModuleLoaded())
                 {
                     LOG_ERROR("can't create new DLSS feature, Fallback to FSR2.2!");
 
-                    Dx11Contexts[handleId].reset();
-                    auto it = std::find_if(Dx11Contexts.begin(), Dx11Contexts.end(), [&handleId](const auto& p) { return p.first == handleId; });
-                    Dx11Contexts.erase(it);
+                    Dx11Contexts[handleId].feature.reset();
+                    Dx11Contexts[handleId].feature = nullptr;
+                    //auto it = std::find_if(Dx11Contexts.begin(), Dx11Contexts.end(), [&handleId](const auto& p) { return p.first == handleId; });
+                    //Dx11Contexts.erase(it);
 
                     Config::Instance()->Dx11Upscaler = "fsr22";
                 }
@@ -430,15 +431,16 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_CreateFeature(ID3D11DeviceContext
 
         if (Config::Instance()->Dx11Upscaler.value_or(defaultUpscaler) == "fsr31_12")
         {
-            Dx11Contexts[handleId] = std::make_unique<FSR31FeatureDx11on12>(handleId, InParameters);
+            Dx11Contexts[handleId].feature = std::make_unique<FSR31FeatureDx11on12>(handleId, InParameters);
 
-            if (!Dx11Contexts[handleId]->ModuleLoaded())
+            if (!Dx11Contexts[handleId].feature->ModuleLoaded())
             {
                 LOG_ERROR("can't create new FSR 3.1 feature, Fallback to FSR2.2!");
 
-                Dx11Contexts[handleId].reset();
-                auto it = std::find_if(Dx11Contexts.begin(), Dx11Contexts.end(), [&handleId](const auto& p) { return p.first == handleId; });
-                Dx11Contexts.erase(it);
+                Dx11Contexts[handleId].feature.reset();
+                Dx11Contexts[handleId].feature = nullptr;
+                //auto it = std::find_if(Dx11Contexts.begin(), Dx11Contexts.end(), [&handleId](const auto& p) { return p.first == handleId; });
+                //Dx11Contexts.erase(it);
 
                 Config::Instance()->Dx11Upscaler = "fsr22";
             }
@@ -451,36 +453,36 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_CreateFeature(ID3D11DeviceContext
         if (Config::Instance()->Dx11Upscaler.value_or(defaultUpscaler) == "fsr22_12")
         {
             LOG_INFO("creating new FSR 2.2.1 with Dx12 feature");
-            Dx11Contexts[handleId] = std::make_unique<FSR2FeatureDx11on12>(handleId, InParameters);
+            Dx11Contexts[handleId].feature = std::make_unique<FSR2FeatureDx11on12>(handleId, InParameters);
         }
         else if (Config::Instance()->Dx11Upscaler.value_or(defaultUpscaler) == "fsr21_12")
         {
             LOG_INFO("creating new FSR 2.1.2 with Dx12 feature");
-            Dx11Contexts[handleId] = std::make_unique<FSR2FeatureDx11on12_212>(handleId, InParameters);
+            Dx11Contexts[handleId].feature = std::make_unique<FSR2FeatureDx11on12_212>(handleId, InParameters);
         }
         else if (Config::Instance()->Dx11Upscaler.value_or(defaultUpscaler) == "fsr22")
         {
             LOG_INFO("creating new native FSR 2.2.1 feature");
-            Dx11Contexts[handleId] = std::make_unique<FSR2FeatureDx11>(handleId, InParameters);
+            Dx11Contexts[handleId].feature = std::make_unique<FSR2FeatureDx11>(handleId, InParameters);
         }
         else if (Config::Instance()->Dx11Upscaler.value_or(defaultUpscaler) == "fsr31")
         {
             LOG_INFO("creating new native FSR 3.1.0 feature");
-            Dx11Contexts[handleId] = std::make_unique<FSR31FeatureDx11>(handleId, InParameters);
+            Dx11Contexts[handleId].feature = std::make_unique<FSR31FeatureDx11>(handleId, InParameters);
         }
         //else if (Config::Instance()->Dx11Upscaler.value_or(defaultUpscaler) == "fsr304")
         //{
         //    LOG_INFO("creating new native FSR 3.1.0 feature");
-        //    Dx11Contexts[handleId] = std::make_unique<FSR31FeatureDx11>(handleId, InParameters);
+        //    Dx11Contexts[handleId].feature = std::make_unique<FSR31FeatureDx11>(handleId, InParameters);
         //}
     }
     else
     {
         LOG_INFO("creating new DLSSD feature");
-        Dx11Contexts[handleId] = std::make_unique<DLSSDFeatureDx11>(handleId, InParameters);
+        Dx11Contexts[handleId].feature = std::make_unique<DLSSDFeatureDx11>(handleId, InParameters);
     }
 
-    auto deviceContext = Dx11Contexts[handleId].get();
+    auto deviceContext = Dx11Contexts[handleId].feature.get();
     *OutHandle = deviceContext->Handle();
 
     if (!D3D11Device)
@@ -539,7 +541,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_ReleaseFeature(NVSDK_NGX_Handle* 
     if (!shutdown)
         LOG_INFO("releasing feature with id {0}", handleId);
 
-    if (auto deviceContext = Dx11Contexts[handleId].get(); deviceContext != nullptr)
+    if (auto deviceContext = Dx11Contexts[handleId].feature.get(); deviceContext != nullptr)
     {
         if (!shutdown)
         {
@@ -553,7 +555,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_ReleaseFeature(NVSDK_NGX_Handle* 
             State::Instance().currentFeature = nullptr;
         }
 
-        Dx11Contexts[handleId].reset();
+        Dx11Contexts[handleId].feature.reset();
         auto it = std::find_if(Dx11Contexts.begin(), Dx11Contexts.end(), [&handleId](const auto& p) { return p.first == handleId; });
         Dx11Contexts.erase(it);
 
@@ -657,35 +659,36 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_EvaluateFeature(ID3D11DeviceConte
         if (State::Instance().newBackend == "" || (!Config::Instance()->DLSSEnabled.value_or_default() && State::Instance().newBackend == "dlss"))
             State::Instance().newBackend = Config::Instance()->Dx11Upscaler.value_or_default();
 
-        changeBackendCounter[handleId]++;
+        Dx11Contexts[handleId].changeBackendCounter++;
 
         // first release everything
-        if (changeBackendCounter[handleId] == 1)
+        if (Dx11Contexts[handleId].changeBackendCounter == 1)
         {
-            if (Dx11Contexts.contains(handleId))
+            if (Dx11Contexts.contains(handleId) && Dx11Contexts[handleId].feature != nullptr)
             {
                 LOG_INFO("changing backend to {0}", State::Instance().newBackend);
 
-                auto dc = Dx11Contexts[handleId].get();
+                auto dc = Dx11Contexts[handleId].feature.get();
 
                 if (State::Instance().newBackend != "dlssd" && State::Instance().newBackend != "dlss")
-                    createParams[handleId] = GetNGXParameters("OptiDx11");
+                    Dx11Contexts[handleId].createParams = GetNGXParameters("OptiDx11");
                 else
-                    createParams[handleId] = InParameters;
+                    Dx11Contexts[handleId].createParams = InParameters;
 
-                createParams[handleId]->Set(NVSDK_NGX_Parameter_DLSS_Feature_Create_Flags, dc->GetFeatureFlags());
-                createParams[handleId]->Set(NVSDK_NGX_Parameter_Width, dc->RenderWidth());
-                createParams[handleId]->Set(NVSDK_NGX_Parameter_Height, dc->RenderHeight());
-                createParams[handleId]->Set(NVSDK_NGX_Parameter_OutWidth, dc->DisplayWidth());
-                createParams[handleId]->Set(NVSDK_NGX_Parameter_OutHeight, dc->DisplayHeight());
-                createParams[handleId]->Set(NVSDK_NGX_Parameter_PerfQualityValue, dc->PerfQualityValue());
+                Dx11Contexts[handleId].createParams->Set(NVSDK_NGX_Parameter_DLSS_Feature_Create_Flags, dc->GetFeatureFlags());
+                Dx11Contexts[handleId].createParams->Set(NVSDK_NGX_Parameter_Width, dc->RenderWidth());
+                Dx11Contexts[handleId].createParams->Set(NVSDK_NGX_Parameter_Height, dc->RenderHeight());
+                Dx11Contexts[handleId].createParams->Set(NVSDK_NGX_Parameter_OutWidth, dc->DisplayWidth());
+                Dx11Contexts[handleId].createParams->Set(NVSDK_NGX_Parameter_OutHeight, dc->DisplayHeight());
+                Dx11Contexts[handleId].createParams->Set(NVSDK_NGX_Parameter_PerfQualityValue, dc->PerfQualityValue());
 
                 LOG_TRACE("sleeping before reset of current feature for 1000ms");
                 std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
-                Dx11Contexts[handleId].reset();
-                auto it = std::find_if(Dx11Contexts.begin(), Dx11Contexts.end(), [&handleId](const auto& p) { return p.first == handleId; });
-                Dx11Contexts.erase(it);
+                Dx11Contexts[handleId].feature.reset();
+                Dx11Contexts[handleId].feature = nullptr;
+                //auto it = std::find_if(Dx11Contexts.begin(), Dx11Contexts.end(), [&handleId](const auto& p) { return p.first == handleId; });
+                //Dx11Contexts.erase(it);
 
                 State::Instance().currentFeature = nullptr;
             }
@@ -696,73 +699,73 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_EvaluateFeature(ID3D11DeviceConte
                 State::Instance().newBackend = "";
                 State::Instance().changeBackend[handleId] = false;
 
-                if (createParams[handleId] != nullptr)
+                if (Dx11Contexts[handleId].createParams != nullptr)
                 {
-                    free(createParams[handleId]);
-                    createParams[handleId] = nullptr;
+                    free(Dx11Contexts[handleId].createParams);
+                    Dx11Contexts[handleId].createParams = nullptr;
                 }
 
-                changeBackendCounter[handleId] = 0;
+                Dx11Contexts[handleId].changeBackendCounter = 0;
             }
 
             return NVSDK_NGX_Result_Success;
         }
 
-        if (changeBackendCounter[handleId] == 2)
+        if (Dx11Contexts[handleId].changeBackendCounter == 2)
         {
             // next frame prepare stuff
             if (State::Instance().newBackend == "xess")
             {
                 Config::Instance()->Dx11Upscaler = "xess";
                 LOG_INFO("creating new XeSS with Dx12 feature");
-                Dx11Contexts[handleId] = std::make_unique<XeSSFeatureDx11>(handleId, createParams[handleId]);
+                Dx11Contexts[handleId].feature = std::make_unique<XeSSFeatureDx11>(handleId, Dx11Contexts[handleId].createParams);
             }
             else if (State::Instance().newBackend == "dlss")
             {
                 Config::Instance()->Dx11Upscaler = "dlss";
                 LOG_INFO("creating new DLSS feature");
-                Dx11Contexts[handleId] = std::make_unique<DLSSFeatureDx11>(handleId, createParams[handleId]);
+                Dx11Contexts[handleId].feature = std::make_unique<DLSSFeatureDx11>(handleId, Dx11Contexts[handleId].createParams);
             }
             else if (State::Instance().newBackend == "dlssd")
             {
                 LOG_INFO("creating new DLSSD feature");
-                Dx11Contexts[handleId] = std::make_unique<DLSSDFeatureDx11>(handleId, InParameters);
+                Dx11Contexts[handleId].feature = std::make_unique<DLSSDFeatureDx11>(handleId, InParameters);
             }
             else if (State::Instance().newBackend == "fsr21_12")
             {
                 Config::Instance()->Dx11Upscaler = "fsr21_12";
                 LOG_INFO("creating new FSR 2.1.2 with Dx12 feature");
-                Dx11Contexts[handleId] = std::make_unique<FSR2FeatureDx11on12_212>(handleId, createParams[handleId]);
+                Dx11Contexts[handleId].feature = std::make_unique<FSR2FeatureDx11on12_212>(handleId, Dx11Contexts[handleId].createParams);
             }
             else if (State::Instance().newBackend == "fsr31_12")
             {
                 Config::Instance()->Dx11Upscaler = "fsr31_12";
                 LOG_INFO("creating new FSR 3.1 with Dx12 feature");
-                Dx11Contexts[handleId] = std::make_unique<FSR31FeatureDx11on12>(handleId, createParams[handleId]);
+                Dx11Contexts[handleId].feature = std::make_unique<FSR31FeatureDx11on12>(handleId, Dx11Contexts[handleId].createParams);
             }
             else if (State::Instance().newBackend == "fsr22_12")
             {
                 Config::Instance()->Dx11Upscaler = "fsr22_12";
                 LOG_INFO("creating new FSR 2.2.1 with Dx12 feature");
-                Dx11Contexts[handleId] = std::make_unique<FSR2FeatureDx11on12>(handleId, createParams[handleId]);
+                Dx11Contexts[handleId].feature = std::make_unique<FSR2FeatureDx11on12>(handleId, Dx11Contexts[handleId].createParams);
             }
             else if (State::Instance().newBackend == "fsr22")
             {
                 Config::Instance()->Dx11Upscaler = "fsr22";
                 LOG_INFO("creating new native FSR 2.2.1 feature");
-                Dx11Contexts[handleId] = std::make_unique<FSR2FeatureDx11>(handleId, createParams[handleId]);
+                Dx11Contexts[handleId].feature = std::make_unique<FSR2FeatureDx11>(handleId, Dx11Contexts[handleId].createParams);
             }
             else if (State::Instance().newBackend == "fsr31")
             {
                 Config::Instance()->Dx11Upscaler = "fsr31";
                 LOG_INFO("creating new native FSR 3.1.0 feature");
-                Dx11Contexts[handleId] = std::make_unique<FSR31FeatureDx11>(handleId, createParams[handleId]);
+                Dx11Contexts[handleId].feature = std::make_unique<FSR31FeatureDx11>(handleId, Dx11Contexts[handleId].createParams);
             }
             //else if (State::Instance().newBackend == "fsr304")
             //{
             //    Config::Instance()->Dx11Upscaler = "fsr31";
             //    LOG_INFO("creating new native FSR 3.1.0 feature");
-            //    Dx11Contexts[handleId] = std::make_unique<FSR31FeatureDx11>(handleId, createParams[handleId]);
+            //    Dx11Contexts[handleId].feature = std::make_unique<FSR31FeatureDx11>(handleId, Dx11Contexts[handleId].createParams);
             //}
 
             if (Config::Instance()->Dx11DelayedInit.value_or_default() &&
@@ -775,10 +778,10 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_EvaluateFeature(ID3D11DeviceConte
             return NVSDK_NGX_Result_Success;
         }
 
-        if (changeBackendCounter[handleId] == 3)
+        if (Dx11Contexts[handleId].changeBackendCounter == 3)
         {
             // then init and continue
-            auto initResult = Dx11Contexts[handleId]->Init(D3D11Device, InDevCtx, createParams[handleId]);
+            auto initResult = Dx11Contexts[handleId].feature->Init(D3D11Device, InDevCtx, Dx11Contexts[handleId].createParams);
 
             if (Config::Instance()->Dx11DelayedInit.value_or_default())
             {
@@ -786,9 +789,9 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_EvaluateFeature(ID3D11DeviceConte
                 std::this_thread::sleep_for(std::chrono::milliseconds(1000));
             }
 
-            changeBackendCounter[handleId] = 0;
+            Dx11Contexts[handleId].changeBackendCounter = 0;
 
-            if (!initResult || !Dx11Contexts[handleId]->ModuleLoaded())
+            if (!initResult || !Dx11Contexts[handleId].feature->ModuleLoaded())
             {
                 LOG_ERROR("init failed with {0} feature", State::Instance().newBackend);
 
@@ -815,20 +818,20 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D11_EvaluateFeature(ID3D11DeviceConte
 
             // if opti nvparam release it
             int optiParam = 0;
-            if (createParams[handleId]->Get("OptiScaler", &optiParam) == NVSDK_NGX_Result_Success && optiParam == 1)
+            if (Dx11Contexts[handleId].createParams->Get("OptiScaler", &optiParam) == NVSDK_NGX_Result_Success && optiParam == 1)
             {
-                free(createParams[handleId]);
-                createParams[handleId] = nullptr;
+                free(Dx11Contexts[handleId].createParams);
+                Dx11Contexts[handleId].createParams = nullptr;
             }
         }
 
         // if initial feature can't be inited
-        State::Instance().currentFeature = Dx11Contexts[handleId].get();
+        State::Instance().currentFeature = Dx11Contexts[handleId].feature.get();
 
         return NVSDK_NGX_Result_Success;
     }
 
-    deviceContext = Dx11Contexts[handleId].get();
+    deviceContext = Dx11Contexts[handleId].feature.get();
     State::Instance().currentFeature = deviceContext;
 
     if (deviceContext == nullptr)

--- a/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
+++ b/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
@@ -1606,36 +1606,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(ID3D12GraphicsCom
     // Record the first timestamp
     if (!State::Instance().isWorkingAsNvngx)
         InCmdList->EndQuery(HooksDx::queryHeap, D3D12_QUERY_TYPE_TIMESTAMP, 0);
-
-    uint32_t outWidth{};
-    uint32_t outHeight{};
-
-    static uint32_t previousOutWidth{};
-    static uint32_t previousOutHeight{};
-
-    InParameters->Get(NVSDK_NGX_Parameter_OutWidth, &outWidth);
-    InParameters->Get(NVSDK_NGX_Parameter_OutHeight, &outHeight);
-
-    if ((deviceContext->Name() == "XeSS" || deviceContext->Name() == "DLSS") && 
-        (outWidth != previousOutWidth || outHeight != previousOutHeight)) 
-    {
-        State::Instance().changeBackend[handleId] = true;
-        previousOutWidth = outWidth;
-        previousOutHeight = outHeight;
-    }
-
-    if (outWidth != 0) {
-        deviceContext->_displayWidth = outWidth;
-        deviceContext->_targetWidth = outWidth;
-    }
-
-    if (outHeight != 0) {
-        deviceContext->_displayHeight = outHeight;
-        deviceContext->_targetHeight = outHeight;
-    }
-
-    LOG_DEBUG("Display: {}x{}, Target: {}x{}, Render: {}x{}", deviceContext->DisplayWidth(), deviceContext->DisplayHeight(), deviceContext->TargetWidth(), deviceContext->TargetHeight(), deviceContext->RenderWidth(), deviceContext->RenderHeight());
-    
+   
     // Run upscaler
     auto evalResult = deviceContext->Evaluate(InCmdList, InParameters);
 

--- a/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
+++ b/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
@@ -1606,7 +1606,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(ID3D12GraphicsCom
     // Record the first timestamp
     if (!State::Instance().isWorkingAsNvngx)
         InCmdList->EndQuery(HooksDx::queryHeap, D3D12_QUERY_TYPE_TIMESTAMP, 0);
-   
+
     // Run upscaler
     auto evalResult = deviceContext->Evaluate(InCmdList, InParameters);
 

--- a/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
+++ b/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
@@ -32,11 +32,11 @@ static UINT64 fgLastFGFrame = 0;
 static UINT fgCallbackFrameIndex = 0;
 
 static ankerl::unordered_dense::map <unsigned int, std::unique_ptr<IFeature_Dx12>> Dx12Contexts;
+static ankerl::unordered_dense::map <unsigned int, NVSDK_NGX_Parameter*> createParams;
+static ankerl::unordered_dense::map <unsigned int, int> changeBackendCounter;
 static ankerl::unordered_dense::map <ID3D12GraphicsCommandList*, ID3D12RootSignature*> computeSignatures;
 static ankerl::unordered_dense::map <ID3D12GraphicsCommandList*, ID3D12RootSignature*> graphicSignatures;
 static ID3D12Device* D3D12Device = nullptr;
-static ankerl::unordered_dense::map <unsigned int, NVSDK_NGX_Parameter*> createParams;
-static ankerl::unordered_dense::map <unsigned int, int> changeBackendCounter;
 static int evalCounter = 0;
 static std::wstring appDataPath = L".";
 static bool shutdown = false;

--- a/OptiScaler/inputs/NVNGX_DLSS_Vk.cpp
+++ b/OptiScaler/inputs/NVNGX_DLSS_Vk.cpp
@@ -813,7 +813,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_VULKAN_EvaluateFeature(VkCommandBuffer 
 
     IFeature_Vk* deviceContext = nullptr;
 
-    if (State::Instance().changeBackend)
+    if (State::Instance().changeBackend[handleId])
     {
         if (State::Instance().newBackend == "" || (!Config::Instance()->DLSSEnabled.value_or_default() && State::Instance().newBackend == "dlss"))
             State::Instance().newBackend = Config::Instance()->VulkanUpscaler.value_or_default();
@@ -859,7 +859,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_VULKAN_EvaluateFeature(VkCommandBuffer 
                 LOG_ERROR("can't find handle {0} in VkContexts!", handleId);
 
                 State::Instance().newBackend = "";
-                State::Instance().changeBackend = false;
+                State::Instance().changeBackend[handleId] = false;
 
                 if (createParams != nullptr)
                 {
@@ -937,12 +937,12 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_VULKAN_EvaluateFeature(VkCommandBuffer 
                 if (State::Instance().newBackend != "dlssd")
                 {
                     State::Instance().newBackend = "fsr21";
-                    State::Instance().changeBackend = true;
+                    State::Instance().changeBackend[handleId] = true;
                 }
                 else
                 {
                     State::Instance().newBackend = "";
-                    State::Instance().changeBackend = false;
+                    State::Instance().changeBackend[handleId] = false;
                     return NVSDK_NGX_Result_Success;
                 }
             }
@@ -951,7 +951,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_VULKAN_EvaluateFeature(VkCommandBuffer 
                 LOG_INFO("init successful for {0}, upscaler changed", State::Instance().newBackend);
 
                 State::Instance().newBackend = "";
-                State::Instance().changeBackend = false;
+                State::Instance().changeBackend[handleId] = false;
                 evalCounter = 0;
             }
 
@@ -976,7 +976,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_VULKAN_EvaluateFeature(VkCommandBuffer 
     if (!deviceContext->IsInited() && Config::Instance()->VulkanUpscaler.value_or_default() != "fsr21")
     {
         State::Instance().newBackend = "fsr21";
-        State::Instance().changeBackend = true;
+        State::Instance().changeBackend[handleId] = true;
         return NVSDK_NGX_Result_Success;
     }
 

--- a/OptiScaler/menu/menu_common.cpp
+++ b/OptiScaler/menu/menu_common.cpp
@@ -1294,7 +1294,8 @@ bool MenuCommon::RenderMenu()
                                 Config::Instance()->DlssReactiveMaskBias.reset();
                             }
 
-                            State::Instance().changeBackend = true;
+                            for (auto& singleChangeBackend : State::Instance().changeBackend)
+                                singleChangeBackend.second = true;
                         }
 
                         ImGui::SameLine(0.0f, 6.0f);
@@ -1830,7 +1831,8 @@ bool MenuCommon::RenderMenu()
                                     {
                                         Config::Instance()->NetworkModel = n;
                                         State::Instance().newBackend = currentBackend;
-                                        State::Instance().changeBackend = true;
+                                        for (auto& singleChangeBackend : State::Instance().changeBackend)
+                                            singleChangeBackend.second = true;
                                     }
                                 }
 
@@ -1890,7 +1892,8 @@ bool MenuCommon::RenderMenu()
                             {
                                 Config::Instance()->Fsr3xIndex = _fsr3xIndex;
                                 State::Instance().newBackend = currentBackend;
-                                State::Instance().changeBackend = true;
+                                for (auto& singleChangeBackend : State::Instance().changeBackend)
+                                    singleChangeBackend.second = true;
                             }
 
                             if (currentFeature->Version().patch > 0)
@@ -2056,7 +2059,8 @@ bool MenuCommon::RenderMenu()
                             else
                                 State::Instance().newBackend = currentBackend;
 
-                            State::Instance().changeBackend = true;
+                            for (auto& singleChangeBackend : State::Instance().changeBackend)
+                                singleChangeBackend.second = true;
                         }
 
                         ImGui::EndDisabled();
@@ -2373,7 +2377,8 @@ bool MenuCommon::RenderMenu()
                                 State::Instance().newBackend = currentBackend;
 
 
-                            State::Instance().changeBackend = true;
+                            for (auto& singleChangeBackend : State::Instance().changeBackend)
+                                singleChangeBackend.second = true;
                         }
                         ImGui::EndDisabled();
 
@@ -2384,7 +2389,7 @@ bool MenuCommon::RenderMenu()
                         if (currentFeature != nullptr)
                         {
                             ImGui::Text("Output Scaling is %s, target res: %dx%d", Config::Instance()->OutputScalingEnabled.value_or_default() ? "ENABLED" : "DISABLED",
-                                        (uint32_t)(currentFeature->DisplayWidth() * _ssRatio), (uint32_t)(currentFeature->DisplayHeight() * _ssRatio));
+                                (uint32_t)(currentFeature->DisplayWidth() * _ssRatio), (uint32_t)(currentFeature->DisplayHeight() * _ssRatio));
                         }
 
                         ImGui::EndDisabled();
@@ -2406,11 +2411,12 @@ bool MenuCommon::RenderMenu()
                         if (currentBackend == "dlss" && State::Instance().currentFeature->Version().major < 3)
                         {
                             State::Instance().newBackend = currentBackend;
-                            State::Instance().changeBackend = true;
+                            for (auto& singleChangeBackend : State::Instance().changeBackend)
+                                singleChangeBackend.second = true;
                         }
                     }
                     ShowHelpMarker("Ignores the value sent by the game\n"
-                                   "and uses the value set below");
+                        "and uses the value set below");
 
                     ImGui::BeginDisabled(!Config::Instance()->OverrideSharpness.value_or_default());
 
@@ -2429,9 +2435,9 @@ bool MenuCommon::RenderMenu()
                     if (bool upOverride = Config::Instance()->UpscaleRatioOverrideEnabled.value_or_default(); ImGui::Checkbox("Ratio Override", &upOverride))
                         Config::Instance()->UpscaleRatioOverrideEnabled = upOverride;
                     ShowHelpMarker("Let's you override every upscaler preset\n"
-                                   "with a value set below\n\n"
-                                   "1.5x on a 1080p screen means internal resolution of 720p\n"
-                                   "1080 / 1.5 = 720");
+                        "with a value set below\n\n"
+                        "1.5x on a 1080p screen means internal resolution of 720p\n"
+                        "1080 / 1.5 = 720");
 
                     ImGui::BeginDisabled(!Config::Instance()->UpscaleRatioOverrideEnabled.value_or_default());
 
@@ -2447,9 +2453,9 @@ bool MenuCommon::RenderMenu()
                     if (bool qOverride = Config::Instance()->QualityRatioOverrideEnabled.value_or_default(); ImGui::Checkbox("Quality Override", &qOverride))
                         Config::Instance()->QualityRatioOverrideEnabled = qOverride;
                     ShowHelpMarker("Let's you override each preset's ratio individually\n"
-                                   "Note that not every game supports every quality preset\n\n"
-                                   "1.5x on a 1080p screen means internal resolution of 720p\n"
-                                   "1080 / 1.5 = 720");
+                        "Note that not every game supports every quality preset\n\n"
+                        "1.5x on a 1080p screen means internal resolution of 720p\n"
+                        "1080 / 1.5 = 720");
 
                     ImGui::BeginDisabled(!Config::Instance()->QualityRatioOverrideEnabled.value_or_default());
 
@@ -2510,10 +2516,11 @@ bool MenuCommon::RenderMenu()
                             else
                                 State::Instance().newBackend = currentBackend;
 
-                            State::Instance().changeBackend = true;
+                            for (auto& singleChangeBackend : State::Instance().changeBackend)
+                                singleChangeBackend.second = true;
                         }
                         ShowHelpMarker("Some Unreal Engine games need this\n"
-                                       "Might fix colors, especially in dark areas");
+                            "Might fix colors, especially in dark areas");
 
                         ImGui::TableNextColumn();
                         if (bool hdr = Config::Instance()->HDR.value_or(false); ImGui::Checkbox("HDR", &hdr))
@@ -2525,7 +2532,8 @@ bool MenuCommon::RenderMenu()
                             else
                                 State::Instance().newBackend = currentBackend;
 
-                            State::Instance().changeBackend = true;
+                            for (auto& singleChangeBackend : State::Instance().changeBackend)
+                                singleChangeBackend.second = true;
                         }
                         ShowHelpMarker("Might help with purple hue in some games");
 
@@ -2548,7 +2556,8 @@ bool MenuCommon::RenderMenu()
                                     else
                                         State::Instance().newBackend = currentBackend;
 
-                                    State::Instance().changeBackend = true;
+                                    for (auto& singleChangeBackend : State::Instance().changeBackend)
+                                        singleChangeBackend.second = true;
                                 }
                                 ShowHelpMarker("You shouldn't need to change it");
 
@@ -2562,7 +2571,8 @@ bool MenuCommon::RenderMenu()
                                     else
                                         State::Instance().newBackend = currentBackend;
 
-                                    State::Instance().changeBackend = true;
+                                    for (auto& singleChangeBackend : State::Instance().changeBackend)
+                                        singleChangeBackend.second = true;
                                 }
                                 ShowHelpMarker("Fix for games that send motion data with preapplied jitter");
 
@@ -2582,10 +2592,11 @@ bool MenuCommon::RenderMenu()
                                     else
                                         State::Instance().newBackend = currentBackend;
 
-                                    State::Instance().changeBackend = true;
+                                    for (auto& singleChangeBackend : State::Instance().changeBackend)
+                                        singleChangeBackend.second = true;
                                 }
                                 ShowHelpMarker("Mostly a fix for Unreal Engine games\n"
-                                               "Top left part of the screen will be blurry");
+                                    "Top left part of the screen will be blurry");
 
                                 ImGui::TableNextColumn();
                                 auto accessToReactiveMask = State::Instance().currentFeature->AccessToReactiveMask();
@@ -2599,7 +2610,8 @@ bool MenuCommon::RenderMenu()
                                     if (currentBackend == "xess")
                                     {
                                         State::Instance().newBackend = currentBackend;
-                                        State::Instance().changeBackend = true;
+                                        for (auto& singleChangeBackend : State::Instance().changeBackend)
+                                            singleChangeBackend.second = true;
                                     }
                                 }
 
@@ -2607,8 +2619,8 @@ bool MenuCommon::RenderMenu()
 
                                 if (accessToReactiveMask)
                                     ShowHelpMarker("Allows the use of a reactive mask\n"
-                                                   "Keep in mind that a reactive mask sent to DLSS\n"
-                                                   "will not produce a good image in combination with FSR/XeSS");
+                                        "Keep in mind that a reactive mask sent to DLSS\n"
+                                        "will not produce a good image in combination with FSR/XeSS");
                                 else
                                     ShowHelpMarker("Option disabled because tha game doesn't provide a reactive mask");
 
@@ -2695,8 +2707,8 @@ bool MenuCommon::RenderMenu()
                             Config::Instance()->ExtendedLimits = extendedLimits;
 
                         ShowHelpMarker("Extended sliders limit for quality presets\n\n"
-                                       "Using this option changes resolution detection logic\n"
-                                       "and might cause issues and crashes!");
+                            "Using this option changes resolution detection logic\n"
+                            "and might cause issues and crashes!");
                     }
 
                     bool pcShaders = Config::Instance()->UsePrecompiledShaders.value_or_default();
@@ -2704,7 +2716,8 @@ bool MenuCommon::RenderMenu()
                     {
                         Config::Instance()->UsePrecompiledShaders = pcShaders;
                         State::Instance().newBackend = currentBackend;
-                        State::Instance().changeBackend = true;
+                        for (auto& singleChangeBackend : State::Instance().changeBackend)
+                            singleChangeBackend.second = true;
                     }
                 }
 

--- a/OptiScaler/upscalers/IFeature.h
+++ b/OptiScaler/upscalers/IFeature.h
@@ -28,10 +28,6 @@ protected:
 
 	unsigned int _renderWidth = 0;
 	unsigned int _renderHeight = 0;
-	unsigned int _targetWidth = 0;
-	unsigned int _targetHeight = 0;
-	unsigned int _displayWidth = 0;
-	unsigned int _displayHeight = 0;
 
 	long _frameCount = 0;
 	bool _moduleLoaded = false;
@@ -48,6 +44,11 @@ public:
 	static unsigned int GetNextHandleId() { return handleCounter++; }
 
 	int GetFeatureFlags() const { return _featureFlags; }
+
+	unsigned int _targetWidth = 0;
+	unsigned int _targetHeight = 0;
+	unsigned int _displayWidth = 0;
+	unsigned int _displayHeight = 0;
 
 	unsigned int DisplayWidth() const { return _displayWidth; };
 	unsigned int DisplayHeight() const { return _displayHeight; };

--- a/OptiScaler/upscalers/IFeature.h
+++ b/OptiScaler/upscalers/IFeature.h
@@ -28,6 +28,10 @@ protected:
 
 	unsigned int _renderWidth = 0;
 	unsigned int _renderHeight = 0;
+	unsigned int _targetWidth = 0;
+	unsigned int _targetHeight = 0;
+	unsigned int _displayWidth = 0;
+	unsigned int _displayHeight = 0;
 
 	long _frameCount = 0;
 	bool _moduleLoaded = false;
@@ -44,11 +48,6 @@ public:
 	static unsigned int GetNextHandleId() { return handleCounter++; }
 
 	int GetFeatureFlags() const { return _featureFlags; }
-
-	unsigned int _targetWidth = 0;
-	unsigned int _targetHeight = 0;
-	unsigned int _displayWidth = 0;
-	unsigned int _displayHeight = 0;
 
 	unsigned int DisplayWidth() const { return _displayWidth; };
 	unsigned int DisplayHeight() const { return _displayHeight; };

--- a/OptiScaler/upscalers/IFeature_Dx11wDx12.cpp
+++ b/OptiScaler/upscalers/IFeature_Dx11wDx12.cpp
@@ -517,7 +517,7 @@ bool IFeature_Dx11wDx12::ProcessDx11Textures(const NVSDK_NGX_Parameter* InParame
         {
             LOG_WARN("AutoExposure disabled but ExposureTexture is not exist, it may cause problems!!");
             State::Instance().AutoExposure = true;
-            State::Instance().changeBackend = true;
+            State::Instance().changeBackend[Handle()->Id] = true;
         }
     }
 
@@ -540,7 +540,7 @@ bool IFeature_Dx11wDx12::ProcessDx11Textures(const NVSDK_NGX_Parameter* InParame
         {
             LOG_WARN("bias mask not exist and it's enabled in config, it may cause problems!!");
             Config::Instance()->DisableReactiveMask.set_volatile_value(true);
-            State::Instance().changeBackend = true;
+            State::Instance().changeBackend[Handle()->Id] = true;
         }
     }
     else

--- a/OptiScaler/upscalers/dlss/DLSSFeature_Dx11.cpp
+++ b/OptiScaler/upscalers/dlss/DLSSFeature_Dx11.cpp
@@ -221,7 +221,7 @@ bool DLSSFeatureDx11::Evaluate(ID3D11DeviceContext* InDeviceContext, NVSDK_NGX_P
             if (!OutputScaler->Dispatch(Device, InDeviceContext, OutputScaler->Buffer(), (ID3D11Texture2D*)paramOutput))
             {
                 Config::Instance()->OutputScalingEnabled.set_volatile_value(false);
-                State::Instance().changeBackend = true;
+                State::Instance().changeBackend[Handle()->Id] = true;
                 return true;
             }
         }

--- a/OptiScaler/upscalers/dlss/DLSSFeature_Dx12.cpp
+++ b/OptiScaler/upscalers/dlss/DLSSFeature_Dx12.cpp
@@ -216,7 +216,7 @@ bool DLSSFeatureDx12::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVSDK_N
 			if (!OutputScaler->Dispatch(Device, InCommandList, OutputScaler->Buffer(), paramOutput))
 			{
 				Config::Instance()->OutputScalingEnabled.set_volatile_value(false);
-				State::Instance().changeBackend = true;
+				State::Instance().changeBackend[Handle()->Id] = true;
 				return true;
 			}
 		}

--- a/OptiScaler/upscalers/dlssd/DLSSDFeature_Dx11.cpp
+++ b/OptiScaler/upscalers/dlssd/DLSSDFeature_Dx11.cpp
@@ -223,7 +223,7 @@ bool DLSSDFeatureDx11::Evaluate(ID3D11DeviceContext* InDeviceContext, NVSDK_NGX_
             if (!OutputScaler->Dispatch(Device, InDeviceContext, OutputScaler->Buffer(), (ID3D11Texture2D*)paramOutput))
             {
                 Config::Instance()->OutputScalingEnabled.set_volatile_value(false);
-                State::Instance().changeBackend = true;
+                State::Instance().changeBackend[Handle()->Id] = true;
                 return true;
             }
         }

--- a/OptiScaler/upscalers/dlssd/DLSSDFeature_Dx12.cpp
+++ b/OptiScaler/upscalers/dlssd/DLSSDFeature_Dx12.cpp
@@ -218,7 +218,7 @@ bool DLSSDFeatureDx12::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVSDK_
 			if (!OutputScaler->Dispatch(Device, InCommandList, OutputScaler->Buffer(), paramOutput))
 			{
 				Config::Instance()->OutputScalingEnabled.set_volatile_value(false);
-				State::Instance().changeBackend = true;
+				State::Instance().changeBackend[Handle()->Id] = true;
 				return true;
 			}
 		}

--- a/OptiScaler/upscalers/fsr2/FSR2Feature_Dx11.cpp
+++ b/OptiScaler/upscalers/fsr2/FSR2Feature_Dx11.cpp
@@ -395,7 +395,7 @@ bool FSR2FeatureDx11::Evaluate(ID3D11DeviceContext* InContext, NVSDK_NGX_Paramet
             {
                 LOG_WARN("MotionVectors MVWidth: {0}, DisplayWidth: {1}, Flag: {2} Disabling DisplaySizeMV!!", desc.Width, DisplayWidth(), displaySizeEnabled);
                 State::Instance().DisplaySizeMV = false;
-                State::Instance().changeBackend = true;
+                State::Instance().changeBackend[Handle()->Id] = true;
                 return true;
             }
 
@@ -479,7 +479,7 @@ bool FSR2FeatureDx11::Evaluate(ID3D11DeviceContext* InContext, NVSDK_NGX_Paramet
         {
             LOG_DEBUG("AutoExposure disabled but ExposureTexture is not exist, it may cause problems!!");
             State::Instance().AutoExposure = true;
-            State::Instance().changeBackend = true;
+            State::Instance().changeBackend[Handle()->Id] = true;
             return true;
         }
     }
@@ -615,7 +615,7 @@ bool FSR2FeatureDx11::Evaluate(ID3D11DeviceContext* InContext, NVSDK_NGX_Paramet
         if (!OutputScaler->Dispatch(Device, InContext, OutputScaler->Buffer(), (ID3D11Texture2D*)paramOutput))
         {
             Config::Instance()->OutputScalingEnabled.set_volatile_value(false);
-            State::Instance().changeBackend = true;
+            State::Instance().changeBackend[Handle()->Id] = true;
             return true;
         }
     }

--- a/OptiScaler/upscalers/fsr2/FSR2Feature_Dx11On12.cpp
+++ b/OptiScaler/upscalers/fsr2/FSR2Feature_Dx11On12.cpp
@@ -197,7 +197,7 @@ bool FSR2FeatureDx11on12::Evaluate(ID3D11DeviceContext* InDeviceContext, NVSDK_N
     }
 
     // AutoExposure is nullptr
-    if (State::Instance().changeBackend)
+    if (State::Instance().changeBackend[Handle()->Id])
     {
         Dx12CommandList->Close();
         ID3D12CommandList* ppCommandLists[] = { Dx12CommandList };
@@ -384,7 +384,7 @@ bool FSR2FeatureDx11on12::Evaluate(ID3D11DeviceContext* InDeviceContext, NVSDK_N
         if (!OutputScaler->Dispatch(Dx12Device, Dx12CommandList, OutputScaler->Buffer(), dx11Out.Dx12Resource))
         {
             Config::Instance()->OutputScalingEnabled.set_volatile_value(false);
-            State::Instance().changeBackend = true;
+            State::Instance().changeBackend[Handle()->Id] = true;
 
             Dx12CommandList->Close();
             ID3D12CommandList* ppCommandLists[] = { Dx12CommandList };

--- a/OptiScaler/upscalers/fsr2/FSR2Feature_Dx12.cpp
+++ b/OptiScaler/upscalers/fsr2/FSR2Feature_Dx12.cpp
@@ -129,7 +129,7 @@ bool FSR2FeatureDx12::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVSDK_N
             {
                 LOG_WARN("MotionVectors MVWidth: {0}, DisplayWidth: {1}, Flag: {2} Disabling DisplaySizeMV!!", desc.Width, TargetWidth(), displaySizeEnabled);
                 State::Instance().DisplaySizeMV = false;
-                State::Instance().changeBackend = true;
+                State::Instance().changeBackend[Handle()->Id] = true;
                 return true;
             }
 
@@ -226,7 +226,7 @@ bool FSR2FeatureDx12::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVSDK_N
         {
             LOG_DEBUG("AutoExposure disabled but ExposureTexture is not exist, it may cause problems!!");
             State::Instance().AutoExposure = true;
-            State::Instance().changeBackend = true;
+            State::Instance().changeBackend[Handle()->Id] = true;
             return true;
         }
     }
@@ -407,7 +407,7 @@ bool FSR2FeatureDx12::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVSDK_N
         if (!OutputScaler->Dispatch(Device, InCommandList, OutputScaler->Buffer(), paramOutput))
         {
             Config::Instance()->OutputScalingEnabled.set_volatile_value(false);
-            State::Instance().changeBackend = true;
+            State::Instance().changeBackend[Handle()->Id] = true;
             return true;
         }
     }

--- a/OptiScaler/upscalers/fsr2/FSR2Feature_Vk.cpp
+++ b/OptiScaler/upscalers/fsr2/FSR2Feature_Vk.cpp
@@ -263,7 +263,7 @@ bool FSR2FeatureVk::Evaluate(VkCommandBuffer InCmdBuffer, NVSDK_NGX_Parameter* I
         {
             LOG_DEBUG("AutoExposure disabled but ExposureTexture is not exist, it may cause problems!!");
             State::Instance().AutoExposure = true;
-            State::Instance().changeBackend = true;
+            State::Instance().changeBackend[Handle()->Id] = true;
             return true;
         }
     }
@@ -298,7 +298,7 @@ bool FSR2FeatureVk::Evaluate(VkCommandBuffer InCmdBuffer, NVSDK_NGX_Parameter* I
         {
             LOG_DEBUG("Bias mask not exist and its enabled in config, it may cause problems!!");
             Config::Instance()->DisableReactiveMask.set_volatile_value(true);
-            State::Instance().changeBackend = true;
+            State::Instance().changeBackend[Handle()->Id] = true;
             return true;
         }
     }

--- a/OptiScaler/upscalers/fsr2_212/FSR2Feature_Dx11On12_212.cpp
+++ b/OptiScaler/upscalers/fsr2_212/FSR2Feature_Dx11On12_212.cpp
@@ -198,7 +198,7 @@ bool FSR2FeatureDx11on12_212::Evaluate(ID3D11DeviceContext* InDeviceContext, NVS
     }
 
     // AutoExposure or ReactiveMask is nullptr
-    if (State::Instance().changeBackend)
+    if (State::Instance().changeBackend[Handle()->Id])
     {
         Dx12CommandList->Close();
         ID3D12CommandList* ppCommandLists[] = { Dx12CommandList };
@@ -390,7 +390,7 @@ bool FSR2FeatureDx11on12_212::Evaluate(ID3D11DeviceContext* InDeviceContext, NVS
         if (!OutputScaler->Dispatch(Dx12Device, Dx12CommandList, OutputScaler->Buffer(), dx11Out.Dx12Resource))
         {
             Config::Instance()->OutputScalingEnabled.set_volatile_value(false);
-            State::Instance().changeBackend = true;
+            State::Instance().changeBackend[Handle()->Id] = true;
 
             Dx12CommandList->Close();
             ID3D12CommandList* ppCommandLists[] = { Dx12CommandList };

--- a/OptiScaler/upscalers/fsr2_212/FSR2Feature_Dx12_212.cpp
+++ b/OptiScaler/upscalers/fsr2_212/FSR2Feature_Dx12_212.cpp
@@ -130,7 +130,7 @@ bool FSR2FeatureDx12_212::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVS
             {
                 LOG_WARN("MotionVectors MVWidth: {0}, DisplayWidth: {1}, Flag: {2} Disabling DisplaySizeMV!!", desc.Width, TargetWidth(), displaySizeEnabled);
                 State::Instance().DisplaySizeMV = false;
-                State::Instance().changeBackend = true;
+                State::Instance().changeBackend[Handle()->Id] = true;
                 return true;
             }
 
@@ -225,7 +225,7 @@ bool FSR2FeatureDx12_212::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVS
         {
             LOG_DEBUG("AutoExposure disabled but ExposureTexture is not exist, it may cause problems!!");
             State::Instance().AutoExposure = true;
-            State::Instance().changeBackend = true;
+            State::Instance().changeBackend[Handle()->Id] = true;
             return true;
         }
     }
@@ -410,7 +410,7 @@ bool FSR2FeatureDx12_212::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVS
         if (!OutputScaler->Dispatch(Device, InCommandList, OutputScaler->Buffer(), paramOutput))
         {
             Config::Instance()->OutputScalingEnabled.set_volatile_value(false);
-            State::Instance().changeBackend = true;
+            State::Instance().changeBackend[Handle()->Id] = true;
             return true;
         }
     }

--- a/OptiScaler/upscalers/fsr2_212/FSR2Feature_Vk_212.cpp
+++ b/OptiScaler/upscalers/fsr2_212/FSR2Feature_Vk_212.cpp
@@ -305,7 +305,7 @@ bool FSR2FeatureVk212::Evaluate(VkCommandBuffer InCmdBuffer, NVSDK_NGX_Parameter
         {
             LOG_DEBUG("AutoExposure disabled but ExposureTexture is not exist, it may cause problems!!");
             State::Instance().AutoExposure = true;
-            State::Instance().changeBackend = true;
+            State::Instance().changeBackend[Handle()->Id] = true;
             return true;
         }
     }
@@ -340,7 +340,7 @@ bool FSR2FeatureVk212::Evaluate(VkCommandBuffer InCmdBuffer, NVSDK_NGX_Parameter
         {
             LOG_DEBUG("Bias mask not exist and its enabled in config, it may cause problems!!");
             Config::Instance()->DisableReactiveMask.set_volatile_value(true);
-            State::Instance().changeBackend = true;
+            State::Instance().changeBackend[Handle()->Id] = true;
             return true;
         }
     }

--- a/OptiScaler/upscalers/fsr31/FSR31Feature_Dx11.cpp
+++ b/OptiScaler/upscalers/fsr31/FSR31Feature_Dx11.cpp
@@ -258,7 +258,7 @@ bool FSR31FeatureDx11::Evaluate(ID3D11DeviceContext* DeviceContext, NVSDK_NGX_Pa
             {
                 LOG_WARN("MotionVectors MVWidth: {0}, DisplayWidth: {1}, Flag: {2} Disabling DisplaySizeMV!!", desc.Width, DisplayWidth(), displaySizeEnabled);
                 State::Instance().DisplaySizeMV = false;
-                State::Instance().changeBackend = true;
+                State::Instance().changeBackend[Handle()->Id] = true;
                 return true;
             }
 
@@ -341,7 +341,7 @@ bool FSR31FeatureDx11::Evaluate(ID3D11DeviceContext* DeviceContext, NVSDK_NGX_Pa
         {
             LOG_DEBUG("AutoExposure disabled but ExposureTexture is not exist, it may cause problems!!");
             State::Instance().AutoExposure = true;
-            State::Instance().changeBackend = true;
+            State::Instance().changeBackend[Handle()->Id] = true;
             return true;
         }
     }
@@ -499,7 +499,7 @@ bool FSR31FeatureDx11::Evaluate(ID3D11DeviceContext* DeviceContext, NVSDK_NGX_Pa
         if (!OutputScaler->Dispatch(Device, DeviceContext, OutputScaler->Buffer(), (ID3D11Texture2D*)paramOutput))
         {
             Config::Instance()->OutputScalingEnabled.set_volatile_value(false);
-            State::Instance().changeBackend = true;
+            State::Instance().changeBackend[Handle()->Id] = true;
             return true;
         }
     }

--- a/OptiScaler/upscalers/fsr31/FSR31Feature_Dx11On12.cpp
+++ b/OptiScaler/upscalers/fsr31/FSR31Feature_Dx11On12.cpp
@@ -215,7 +215,7 @@ bool FSR31FeatureDx11on12::Evaluate(ID3D11DeviceContext* InDeviceContext, NVSDK_
     }
 
     // AutoExposure or ReactiveMask is nullptr
-    if (State::Instance().changeBackend)
+    if (State::Instance().changeBackend[Handle()->Id])
     {
         Dx12CommandList->Close();
         ID3D12CommandList* ppCommandLists[] = { Dx12CommandList };
@@ -426,7 +426,7 @@ bool FSR31FeatureDx11on12::Evaluate(ID3D11DeviceContext* InDeviceContext, NVSDK_
         if (!OutputScaler->Dispatch(Dx12Device, Dx12CommandList, OutputScaler->Buffer(), dx11Out.Dx12Resource))
         {
             Config::Instance()->OutputScalingEnabled.set_volatile_value(false);
-            State::Instance().changeBackend = true;
+            State::Instance().changeBackend[Handle()->Id] = true;
 
             Dx12CommandList->Close();
             ID3D12CommandList* ppCommandLists[] = { Dx12CommandList };

--- a/OptiScaler/upscalers/fsr31/FSR31Feature_Dx12.cpp
+++ b/OptiScaler/upscalers/fsr31/FSR31Feature_Dx12.cpp
@@ -147,7 +147,7 @@ bool FSR31FeatureDx12::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVSDK_
             {
                 LOG_WARN("MotionVectors MVWidth: {0}, DisplayWidth: {1}, Flag: {2} Disabling DisplaySizeMV!!", desc.Width, TargetWidth(), displaySizeEnabled);
                 State::Instance().DisplaySizeMV = false;
-                State::Instance().changeBackend = true;
+                State::Instance().changeBackend[Handle()->Id] = true;
                 return true;
             }
 
@@ -245,7 +245,7 @@ bool FSR31FeatureDx12::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVSDK_
         {
             LOG_DEBUG("AutoExposure disabled but ExposureTexture is not exist, it may cause problems!!");
             State::Instance().AutoExposure = true;
-            State::Instance().changeBackend = true;
+            State::Instance().changeBackend[Handle()->Id] = true;
             return true;
         }
     }
@@ -451,7 +451,7 @@ bool FSR31FeatureDx12::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVSDK_
         if (!OutputScaler->Dispatch(Device, InCommandList, OutputScaler->Buffer(), paramOutput))
         {
             Config::Instance()->OutputScalingEnabled.set_volatile_value(false);
-            State::Instance().changeBackend = true;
+            State::Instance().changeBackend[Handle()->Id] = true;
             return true;
         }
     }

--- a/OptiScaler/upscalers/fsr31/FSR31Feature_Vk.cpp
+++ b/OptiScaler/upscalers/fsr31/FSR31Feature_Vk.cpp
@@ -416,7 +416,7 @@ bool FSR31FeatureVk::Evaluate(VkCommandBuffer InCmdBuffer, NVSDK_NGX_Parameter* 
         {
             LOG_DEBUG("AutoExposure disabled but ExposureTexture is not exist, it may cause problems!!");
             State::Instance().AutoExposure = true;
-            State::Instance().changeBackend = true;
+            State::Instance().changeBackend[Handle()->Id] = true;
             return true;
         }
     }
@@ -451,7 +451,7 @@ bool FSR31FeatureVk::Evaluate(VkCommandBuffer InCmdBuffer, NVSDK_NGX_Parameter* 
         {
             LOG_DEBUG("Bias mask not exist and its enabled in config, it may cause problems!!");
             Config::Instance()->DisableReactiveMask.set_volatile_value(true);
-            State::Instance().changeBackend = true;
+            State::Instance().changeBackend[Handle()->Id] = true;
             return true;
         }
     }

--- a/OptiScaler/upscalers/xess/XeSSFeature_Dx11.cpp
+++ b/OptiScaler/upscalers/xess/XeSSFeature_Dx11.cpp
@@ -217,7 +217,7 @@ bool XeSSFeatureDx11::Evaluate(ID3D11DeviceContext* InDeviceContext, NVSDK_NGX_P
 		LOG_DEBUG("ProcessDx11Textures complete!");
 
 	// AutoExposure or ReactiveMask is nullptr
-	if (State::Instance().changeBackend)
+	if (State::Instance().changeBackend[Handle()->Id])
 	{
 		Dx12CommandList->Close();
 		ID3D12CommandList* ppCommandLists[] = { Dx12CommandList };
@@ -398,7 +398,7 @@ bool XeSSFeatureDx11::Evaluate(ID3D11DeviceContext* InDeviceContext, NVSDK_NGX_P
 		if (!OutputScaler->Dispatch(Dx12Device, Dx12CommandList, OutputScaler->Buffer(), dx11Out.Dx12Resource))
 		{
 			Config::Instance()->OutputScalingEnabled.set_volatile_value(false);
-			State::Instance().changeBackend = true;
+			State::Instance().changeBackend[Handle()->Id] = true;
 
 			Dx12CommandList->Close();
 			ID3D12CommandList* ppCommandLists[] = { Dx12CommandList };

--- a/OptiScaler/upscalers/xess/XeSSFeature_Dx12.cpp
+++ b/OptiScaler/upscalers/xess/XeSSFeature_Dx12.cpp
@@ -137,7 +137,7 @@ bool XeSSFeatureDx12::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVSDK_N
 			{
 				LOG_WARN("MotionVectors MVWidth: {0}, DisplayWidth: {1}, Flag: {2} Disabling DisplaySizeMV!!", desc.Width, DisplayWidth(), displaySizeEnabled);
 				State::Instance().DisplaySizeMV = false;
-				State::Instance().changeBackend = true;
+				State::Instance().changeBackend[Handle()->Id] = true;
 				return true;
 			}
 
@@ -234,7 +234,7 @@ bool XeSSFeatureDx12::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVSDK_N
 		{
 			LOG_WARN("AutoExposure disabled but ExposureTexture is not exist, it may cause problems!!");
 			State::Instance().AutoExposure = true;
-			State::Instance().changeBackend = true;
+			State::Instance().changeBackend[Handle()->Id] = true;
 			return true;
 		}
 	}
@@ -269,7 +269,7 @@ bool XeSSFeatureDx12::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVSDK_N
 		{
 			LOG_WARN("Bias mask not exist and its enabled in config, it may cause problems!!");
 			Config::Instance()->DisableReactiveMask.set_volatile_value(true);
-			State::Instance().changeBackend = true;
+			State::Instance().changeBackend[Handle()->Id] = true;
 			return true;
 		}
 	}
@@ -363,7 +363,7 @@ bool XeSSFeatureDx12::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVSDK_N
 		if (!OutputScaler->Dispatch(Device, InCommandList, OutputScaler->Buffer(), paramOutput))
 		{
 			Config::Instance()->OutputScalingEnabled.set_volatile_value(false);
-			State::Instance().changeBackend = true;
+			State::Instance().changeBackend[Handle()->Id] = true;
 			return true;
 		}
 	}


### PR DESCRIPTION
Ties reinit variables with handle id.

Fixes a crash when trying to change an upscaler in Split Fiction