### PR TITLE
Split Fiction fixes

### DIFF
--- a/OptiScaler/State.h
+++ b/OptiScaler/State.h
@@ -21,7 +21,8 @@ typedef enum GameQuirk
 	Cyberpunk,
 	FMF2,
 	RDR1,
-	Banishers
+	Banishers,
+	SplitFiction
 } GameQuirk;
 
 typedef enum FGType : uint32_t

--- a/OptiScaler/dllmain.cpp
+++ b/OptiScaler/dllmain.cpp
@@ -2398,6 +2398,11 @@ static void CheckQuirks() {
             LOG_INFO("Enabling a quirk for Banishers (Disable FSR2 Inputs)");
         }
     }
+    else if (exePathFilename == "SplitFiction.exe")
+    {
+        State::Instance().gameQuirk = SplitFiction;
+        LOG_INFO("Enabling a quirk for Split Fiction (Quick upscaler reinit)");
+    }
 }
 
 bool isNvidia()

--- a/OptiScaler/inputs/FfxApi_Dx12.cpp
+++ b/OptiScaler/inputs/FfxApi_Dx12.cpp
@@ -51,10 +51,14 @@ static bool CreateDLSSContext(ffxContext handle, const ffxDispatchDescUpscale* p
     params->Set(NVSDK_NGX_Parameter_Height, pExecParams->renderSize.height);
     params->Set(NVSDK_NGX_Parameter_OutWidth, initParams->maxUpscaleSize.width);
     params->Set(NVSDK_NGX_Parameter_OutHeight, initParams->maxUpscaleSize.height);
+    params->Set("FSR.upscaleSize.width", pExecParams->upscaleSize.width);
+    params->Set("FSR.upscaleSize.height", pExecParams->upscaleSize.height);
 
-    auto ratio = (float)initParams->maxUpscaleSize.width / (float)pExecParams->renderSize.width;
+    auto width = pExecParams->upscaleSize.width > 0 ? pExecParams->upscaleSize.width : initParams->maxUpscaleSize.width;
 
-    LOG_INFO("renderWidth: {}, maxWidth: {}, ratio: {}", pExecParams->renderSize.width, initParams->maxUpscaleSize.width, ratio);
+    auto ratio = (float)width / (float)pExecParams->renderSize.width;
+
+    LOG_INFO("renderWidth: {}, maxWidth: {}, ratio: {}", pExecParams->renderSize.width, width, ratio);
 
     if (ratio <= 3.0)
         params->Set(NVSDK_NGX_Parameter_PerfQualityValue, NVSDK_NGX_PerfQuality_Value_UltraPerformance);

--- a/OptiScaler/inputs/FfxApi_Vk.cpp
+++ b/OptiScaler/inputs/FfxApi_Vk.cpp
@@ -183,10 +183,14 @@ static bool CreateDLSSContext(ffxContext handle, const ffxDispatchDescUpscale* p
     params->Set(NVSDK_NGX_Parameter_Height, pExecParams->renderSize.height);
     params->Set(NVSDK_NGX_Parameter_OutWidth, initParams->maxUpscaleSize.width);
     params->Set(NVSDK_NGX_Parameter_OutHeight, initParams->maxUpscaleSize.height);
+    params->Set("FSR.upscaleSize.width", pExecParams->upscaleSize.width);
+    params->Set("FSR.upscaleSize.height", pExecParams->upscaleSize.height);
 
-    auto ratio = (float)initParams->maxUpscaleSize.width / (float)pExecParams->renderSize.width;
+    auto width = pExecParams->upscaleSize.width > 0 ? pExecParams->upscaleSize.width : initParams->maxUpscaleSize.width;
 
-    LOG_INFO("renderWidth: {}, maxWidth: {}, ratio: {}", pExecParams->renderSize.width, initParams->maxUpscaleSize.width, ratio);
+    auto ratio = (float)width / (float)pExecParams->renderSize.width;
+
+    LOG_INFO("renderWidth: {}, maxWidth: {}, ratio: {}", pExecParams->renderSize.width, width, ratio);
 
     if (ratio <= 3.0)
         params->Set(NVSDK_NGX_Parameter_PerfQualityValue, NVSDK_NGX_PerfQuality_Value_UltraPerformance);

--- a/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
+++ b/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
@@ -1159,8 +1159,12 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(ID3D12GraphicsCom
 
     IFeature_Dx12* deviceContext = nullptr;
 
-    if (Dx12Contexts[handleId].feature && Dx12Contexts[handleId].feature.get()->UpdateOutputResolution(InParameters) /* && not FSR 3.1 */) {
-        State::Instance().changeBackend[handleId] = true;
+    if (Dx12Contexts[handleId].feature) {
+        auto* feature = Dx12Contexts[handleId].feature.get();
+
+        // FSR 3.1 supports upscaleSize that doesn't need reinit to change output resolution
+        if (!std::string(feature->Name()).starts_with("FSR 3.1") && feature->Name() != "FSR3 w/Dx12" && feature->UpdateOutputResolution(InParameters))
+            State::Instance().changeBackend[handleId] = true;
     }
 
     // Change backend
@@ -1202,8 +1206,15 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(ID3D12GraphicsCom
 
                 dc = nullptr;
 
-                LOG_DEBUG("sleeping before reset of current feature for 1000ms");
-                std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+                if (State::Instance().gameQuirk = SplitFiction) {
+                    LOG_DEBUG("sleeping before reset of current feature for 100ms (Split Fiction)");
+                    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                }
+                else 
+                {
+                    LOG_DEBUG("sleeping before reset of current feature for 1000ms");
+                    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+                }
 
                 Dx12Contexts[handleId].feature.reset();
                 Dx12Contexts[handleId].feature = nullptr;
@@ -1348,7 +1359,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(ID3D12GraphicsCom
         State::Instance().currentFeature = Dx12Contexts[handleId].feature.get();
         FrameGen_Dx12::fgTarget = 20;
 
-        return NVSDK_NGX_Result_Success;
+        //return NVSDK_NGX_Result_Success;
     }
 
     deviceContext = Dx12Contexts[handleId].feature.get();

--- a/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
+++ b/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
@@ -1159,6 +1159,10 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(ID3D12GraphicsCom
 
     IFeature_Dx12* deviceContext = nullptr;
 
+    if (Dx12Contexts[handleId].feature && Dx12Contexts[handleId].feature.get()->UpdateOutputResolution(InParameters) /* && not FSR 3.1 */) {
+        State::Instance().changeBackend[handleId] = true;
+    }
+
     // Change backend
     if (State::Instance().changeBackend[handleId])
     {

--- a/OptiScaler/upscalers/IFeature.cpp
+++ b/OptiScaler/upscalers/IFeature.cpp
@@ -196,8 +196,16 @@ bool IFeature::UpdateOutputResolution(const NVSDK_NGX_Parameter* InParameters)
 	return false;
 }
 
-void IFeature::GetDynamicOutputResolution(const NVSDK_NGX_Parameter* InParameters, unsigned int* width, unsigned int* height)
+void IFeature::GetDynamicOutputResolution(NVSDK_NGX_Parameter* InParameters, unsigned int* width, unsigned int* height)
 {
+	// FSR 3.1 uses upscaleSize for this, max size should stay the same
+	int supportsUpscaleSize = 0;
+	InParameters->Get("OptiScaler.SupportsUpscaleSize", &supportsUpscaleSize);
+	if (supportsUpscaleSize) {
+		InParameters->Set("OptiScaler.SupportsUpscaleSize", 0);
+		return;
+	}
+
 	// Check for FSR's dynamic resolution output
 	auto fsrDynamicOutputWidth = 0;
 	auto fsrDynamicOutputHeight = 0;

--- a/OptiScaler/upscalers/IFeature.h
+++ b/OptiScaler/upscalers/IFeature.h
@@ -39,7 +39,7 @@ protected:
 	void SetHandle(unsigned int InHandleId);
 	bool SetInitParameters(NVSDK_NGX_Parameter* InParameters);
 	void GetRenderResolution(NVSDK_NGX_Parameter* InParameters, unsigned int* OutWidth, unsigned int* OutHeight);
-	void GetDynamicOutputResolution(const NVSDK_NGX_Parameter* InParameters, unsigned int* width, unsigned int* height);
+	void GetDynamicOutputResolution(NVSDK_NGX_Parameter* InParameters, unsigned int* width, unsigned int* height);
 	float GetSharpness(const NVSDK_NGX_Parameter* InParameters);
 
 	virtual void SetInit(bool InValue) { _isInited = InValue; }

--- a/OptiScaler/upscalers/IFeature.h
+++ b/OptiScaler/upscalers/IFeature.h
@@ -39,6 +39,7 @@ protected:
 	void SetHandle(unsigned int InHandleId);
 	bool SetInitParameters(NVSDK_NGX_Parameter* InParameters);
 	void GetRenderResolution(NVSDK_NGX_Parameter* InParameters, unsigned int* OutWidth, unsigned int* OutHeight);
+	void GetDynamicOutputResolution(const NVSDK_NGX_Parameter* InParameters, unsigned int* width, unsigned int* height);
 	float GetSharpness(const NVSDK_NGX_Parameter* InParameters);
 
 	virtual void SetInit(bool InValue) { _isInited = InValue; }
@@ -49,6 +50,7 @@ public:
 
 	int GetFeatureFlags() const { return _featureFlags; }
 
+	bool UpdateOutputResolution(const NVSDK_NGX_Parameter* InParameters);
 	unsigned int DisplayWidth() const { return _displayWidth; };
 	unsigned int DisplayHeight() const { return _displayHeight; };
 	unsigned int TargetWidth() const { return _targetWidth; };

--- a/OptiScaler/upscalers/fsr31/FSR31Feature_Dx11.cpp
+++ b/OptiScaler/upscalers/fsr31/FSR31Feature_Dx11.cpp
@@ -444,8 +444,11 @@ bool FSR31FeatureDx11::Evaluate(ID3D11DeviceContext* DeviceContext, NVSDK_NGX_Pa
             LOG_WARN("Velocity configure result: {}", (UINT)result);
     }
 
-    InParameters->Get("FSR.upscaleSize.width", &params.upscaleSize.width);
-    InParameters->Get("FSR.upscaleSize.height", &params.upscaleSize.height);
+    if (InParameters->Get("FSR.upscaleSize.width", &params.upscaleSize.width) == NVSDK_NGX_Result_Success && Config::Instance()->OutputScalingEnabled.value_or_default())
+        params.upscaleSize.width *= Config::Instance()->OutputScalingMultiplier.value_or_default();
+
+    if (InParameters->Get("FSR.upscaleSize.height", &params.upscaleSize.height) == NVSDK_NGX_Result_Success && Config::Instance()->OutputScalingEnabled.value_or_default())
+        params.upscaleSize.height *= Config::Instance()->OutputScalingMultiplier.value_or_default();
 
     LOG_DEBUG("Dispatch!!");
     auto result = ffxFsr3ContextDispatchUpscale(&_upscalerContext, &params);

--- a/OptiScaler/upscalers/fsr31/FSR31Feature_Dx11On12.cpp
+++ b/OptiScaler/upscalers/fsr31/FSR31Feature_Dx11On12.cpp
@@ -6,7 +6,12 @@
 
 #include "FSR31Feature_Dx11On12.h"
 
-FSR31FeatureDx11on12::FSR31FeatureDx11on12(unsigned int InHandleId, NVSDK_NGX_Parameter* InParameters) : FSR31Feature(InHandleId, InParameters), IFeature_Dx11wDx12(InHandleId, InParameters), IFeature_Dx11(InHandleId, InParameters), IFeature(InHandleId, InParameters)
+NVSDK_NGX_Parameter* FSR31FeatureDx11on12::SetParameters(NVSDK_NGX_Parameter* InParameters) {
+    InParameters->Set("OptiScaler.SupportsUpscaleSize", true);
+    return InParameters;
+}
+
+FSR31FeatureDx11on12::FSR31FeatureDx11on12(unsigned int InHandleId, NVSDK_NGX_Parameter* InParameters) : FSR31Feature(InHandleId, InParameters), IFeature_Dx11wDx12(InHandleId, InParameters), IFeature_Dx11(InHandleId, InParameters), IFeature(InHandleId, SetParameters(InParameters))
 {
     _moduleLoaded = FfxApiProxy::InitFfxDx12();
 

--- a/OptiScaler/upscalers/fsr31/FSR31Feature_Dx11On12.cpp
+++ b/OptiScaler/upscalers/fsr31/FSR31Feature_Dx11On12.cpp
@@ -339,8 +339,11 @@ bool FSR31FeatureDx11on12::Evaluate(ID3D11DeviceContext* InDeviceContext, NVSDK_
             LOG_WARN("Velocity configure result: {}", (UINT)result);
     }
 
-    InParameters->Get("FSR.upscaleSize.width", &params.upscaleSize.width);
-    InParameters->Get("FSR.upscaleSize.height", &params.upscaleSize.height);
+    if (InParameters->Get("FSR.upscaleSize.width", &params.upscaleSize.width) == NVSDK_NGX_Result_Success && Config::Instance()->OutputScalingEnabled.value_or_default())
+        params.upscaleSize.width *= Config::Instance()->OutputScalingMultiplier.value_or_default();
+
+    if (InParameters->Get("FSR.upscaleSize.height", &params.upscaleSize.height) == NVSDK_NGX_Result_Success && Config::Instance()->OutputScalingEnabled.value_or_default())
+        params.upscaleSize.height *= Config::Instance()->OutputScalingMultiplier.value_or_default();
 
     LOG_DEBUG("Dispatch!!");
     auto ffxresult = FfxApiProxy::D3D12_Dispatch()(&_context, &params.header);

--- a/OptiScaler/upscalers/fsr31/FSR31Feature_Dx11On12.h
+++ b/OptiScaler/upscalers/fsr31/FSR31Feature_Dx11On12.h
@@ -10,6 +10,7 @@ class FSR31FeatureDx11on12 : public FSR31Feature, public IFeature_Dx11wDx12
 {
 private:
 	bool _baseInit = false;
+	NVSDK_NGX_Parameter* SetParameters(NVSDK_NGX_Parameter* InParameters);
 
 protected:
 	bool InitFSR3(const NVSDK_NGX_Parameter* InParameters);

--- a/OptiScaler/upscalers/fsr31/FSR31Feature_Dx12.cpp
+++ b/OptiScaler/upscalers/fsr31/FSR31Feature_Dx12.cpp
@@ -6,7 +6,12 @@
 
 #include "FSR31Feature_Dx12.h"
 
-FSR31FeatureDx12::FSR31FeatureDx12(unsigned int InHandleId, NVSDK_NGX_Parameter* InParameters) : FSR31Feature(InHandleId, InParameters), IFeature_Dx12(InHandleId, InParameters), IFeature(InHandleId, InParameters)
+NVSDK_NGX_Parameter* FSR31FeatureDx12::SetParameters(NVSDK_NGX_Parameter* InParameters) {
+    InParameters->Set("OptiScaler.SupportsUpscaleSize", true);
+    return InParameters;
+}
+
+FSR31FeatureDx12::FSR31FeatureDx12(unsigned int InHandleId, NVSDK_NGX_Parameter* InParameters) : FSR31Feature(InHandleId, InParameters), IFeature_Dx12(InHandleId, InParameters), IFeature(InHandleId, SetParameters(InParameters))
 {
     _moduleLoaded = FfxApiProxy::InitFfxDx12();
 
@@ -402,6 +407,12 @@ bool FSR31FeatureDx12::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVSDK_
     if (result != FFX_API_RETURN_OK)
     {
         LOG_ERROR("_dispatch error: {0}", FfxApiProxy::ReturnCodeToString(result));
+
+        if (result == FFX_API_RETURN_ERROR_RUNTIME_ERROR) {
+            LOG_WARN("Trying to recover by recreating the feature");
+            State::Instance().changeBackend[Handle()->Id] = true;
+        }
+
         return false;
     }
 

--- a/OptiScaler/upscalers/fsr31/FSR31Feature_Dx12.cpp
+++ b/OptiScaler/upscalers/fsr31/FSR31Feature_Dx12.cpp
@@ -390,8 +390,11 @@ bool FSR31FeatureDx12::Evaluate(ID3D12GraphicsCommandList* InCommandList, NVSDK_
             LOG_WARN("Velocity configure result: {}", (UINT)result);
     }
 
-    InParameters->Get("FSR.upscaleSize.width", &params.upscaleSize.width);
-    InParameters->Get("FSR.upscaleSize.height", &params.upscaleSize.height);
+    if (InParameters->Get("FSR.upscaleSize.width", &params.upscaleSize.width) == NVSDK_NGX_Result_Success && Config::Instance()->OutputScalingEnabled.value_or_default())
+        params.upscaleSize.width *= Config::Instance()->OutputScalingMultiplier.value_or_default();
+
+    if (InParameters->Get("FSR.upscaleSize.height", &params.upscaleSize.height) == NVSDK_NGX_Result_Success && Config::Instance()->OutputScalingEnabled.value_or_default())
+        params.upscaleSize.height *= Config::Instance()->OutputScalingMultiplier.value_or_default();
 
     LOG_DEBUG("Dispatch!!");
     auto result = FfxApiProxy::D3D12_Dispatch()(&_context, &params.header);

--- a/OptiScaler/upscalers/fsr31/FSR31Feature_Dx12.h
+++ b/OptiScaler/upscalers/fsr31/FSR31Feature_Dx12.h
@@ -8,6 +8,7 @@
 class FSR31FeatureDx12 : public FSR31Feature, public IFeature_Dx12
 {
 private:
+	NVSDK_NGX_Parameter* SetParameters(NVSDK_NGX_Parameter* InParameters);
 
 protected:
 	bool InitFSR3(const NVSDK_NGX_Parameter* InParameters);

--- a/OptiScaler/upscalers/fsr31/FSR31Feature_Vk.cpp
+++ b/OptiScaler/upscalers/fsr31/FSR31Feature_Vk.cpp
@@ -542,8 +542,11 @@ bool FSR31FeatureVk::Evaluate(VkCommandBuffer InCmdBuffer, NVSDK_NGX_Parameter* 
             LOG_WARN("Velocity configure result: {}", (UINT)result);
     }
 
-    InParameters->Get("FSR.upscaleSize.width", &params.upscaleSize.width);
-    InParameters->Get("FSR.upscaleSize.height", &params.upscaleSize.height);
+    if (InParameters->Get("FSR.upscaleSize.width", &params.upscaleSize.width) == NVSDK_NGX_Result_Success && Config::Instance()->OutputScalingEnabled.value_or_default())
+        params.upscaleSize.width *= Config::Instance()->OutputScalingMultiplier.value_or_default();
+
+    if (InParameters->Get("FSR.upscaleSize.height", &params.upscaleSize.height) == NVSDK_NGX_Result_Success && Config::Instance()->OutputScalingEnabled.value_or_default())
+        params.upscaleSize.height *= Config::Instance()->OutputScalingMultiplier.value_or_default();
 
     LOG_DEBUG("Dispatch!!");
     auto result = FfxApiProxy::VULKAN_Dispatch()(&_context, &params.header);


### PR DESCRIPTION
Includes fixes/workarounds for:
- output scaling when using upscaleSize
- Non-FSR 3.1 upscalers not supporting upscaleSize resulting in a stretched image, emulated by reiniting the upscaler
- speeding up upscaler init to make certain transitions in Split Fiction smoother when used with Non-FSR 3.1 upscalers 

More can be done in the future

https://github.com/user-attachments/assets/c33b4f79-75b2-40f0-8766-cf0984fec9d4

