### PR TITLE
Add ink level to the overlay

### DIFF
--- a/OptiScaler.ini
+++ b/OptiScaler.ini
@@ -1,4 +1,13 @@
 ; -------------------------------------------------------
+[Printers]
+; -------------------------------------------------------
+; Ip of the printer, currently only Brother printers with web ui are supported
+; x.x.x.x - Default (auto) is disabled functionality
+PrinterIP=auto
+
+
+
+; -------------------------------------------------------
 [Upscalers]
 ; -------------------------------------------------------
 ; Select upscaler for Dx11 games

--- a/OptiScaler/Config.cpp
+++ b/OptiScaler/Config.cpp
@@ -43,6 +43,11 @@ bool Config::Reload(std::filesystem::path iniPath)
     {
         State::Instance().nvngxIniDetected = exists(iniPath.parent_path() / "nvngx.ini");
 
+        // Printers
+        {
+            PrinterIP.set_from_config(readString("Printers", "PrinterIP", true));
+        }
+
         // Upscalers
         {
             Dx11Upscaler.set_from_config(readString("Upscalers", "Dx11Upscaler", true));
@@ -529,6 +534,11 @@ bool Config::SaveIni()
             ini.SetValue("FrameGeneration", "FrameGenerationMode", "dynamic");
         else
             ini.SetValue("FrameGeneration", "FrameGenerationMode", "auto");
+    }
+
+    // Printers
+    {
+        ini.SetValue("Printers", "PrinterIP", Instance()->PrinterIP.value_for_config_or("auto").c_str());
     }
 
     // Upscalers 

--- a/OptiScaler/Config.h
+++ b/OptiScaler/Config.h
@@ -124,6 +124,9 @@ class Config
 public:
 	Config();
 
+	// Printers
+	CustomOptional<std::string, NoDefault> PrinterIP;
+
 	// Init flags
 	CustomOptional<bool, NoDefault> DepthInverted;
 	CustomOptional<bool, NoDefault> AutoExposure;

--- a/OptiScaler/State.h
+++ b/OptiScaler/State.h
@@ -39,6 +39,9 @@ public:
         return instance;
     }
 
+	std::map<std::string, int> inkLevels;
+	std::string printerName;
+
 	// Init flags
 	// Used per feature
 	// Reseting on creation of new feature


### PR DESCRIPTION
A long awaited feature was finally added - printer ink status.

You will finally be able to monitor your ink level even while being busy playing. 
No longer will you find yourself being surprised by low ink after a long play session. You might even see how your ink levels fluctuate while you play, even if you haven’t printed anything!

We strongly encourage users to collect data about their ink usage and share them with us. This will allow us to improve the **AI** powered ink prediction algorithm to be even more accurate.

Currently only Brother printers with web ui are supported. PRs are open if you want to add support for more! 
Set your printer's IP in ``OptiScaler.ini`` under the PrinterIP setting.

![image](https://github.com/user-attachments/assets/06f1c9d9-fd72-4d59-91db-212829c41261)
