### PR TITLE
ci: run release check before creation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,24 +90,6 @@ jobs:
         echo "Version: ${{ steps.get_version.outputs.version }}"
         echo "Filename: ${{ steps.get_version.outputs.filename }}"
         
-    - name: Create Nightly Release (if not exists)
-      id: create_release
-      if: steps.check_release.outputs.release_exists == 'false'
-      uses: actions/github-script@v6
-      with:
-        script: |
-          const release = await github.rest.repos.createRelease({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            tag_name: "nightly",
-            name: "Nightly Builds",
-            body: "This is an automated nightly build release.",
-            draft: false,
-            prerelease: true,
-          });
-          core.setOutput("release_id", release.data.id);
-          core.setOutput("upload_url", release.data.upload_url);
-
     - name: Check Existing Release
       id: check_release
       uses: actions/github-script@v6
@@ -130,6 +112,24 @@ jobs:
               throw error;
             }
           }
+
+    - name: Create Nightly Release (if not exists)
+      id: create_release
+      if: steps.check_release.outputs.release_exists == 'false'
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const release = await github.rest.repos.createRelease({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            tag_name: "nightly",
+            name: "Nightly Builds",
+            body: "This is an automated nightly build release.",
+            draft: false,
+            prerelease: true,
+          });
+          core.setOutput("release_id", release.data.id);
+          core.setOutput("upload_url", release.data.upload_url);
 
     - name: Get Commit Messages From Last Day and Update the Release
       id: commit_messages


### PR DESCRIPTION
This was probably not a problem because there was always a previous nightly release. Still here is a fix for completeness sake