### PR TITLE
Fix graphical corruptions in No Man's Sky on older AMD cards

### DIFF
--- a/OptiScaler/State.h
+++ b/OptiScaler/State.h
@@ -24,6 +24,7 @@ enum class GameQuirk
     FastFeatureReset,
     LoadD3D12Manually,
     KernelBaseHooks,
+    VulkanDLSSBarrierFixup,
     _
 };
 

--- a/OptiScaler/dllmain.cpp
+++ b/OptiScaler/dllmain.cpp
@@ -666,10 +666,9 @@ static void CheckWorkingMode()
                     HookForVulkanExtensionSpoofing(vulkanModule);
                     HookForVulkanVRAMSpoofing(vulkanModule);
                 }
-            }
 
-            if (Config::Instance()->OverlayMenu.value() && vulkanModule != nullptr)
                 HooksVk::HookVk(vulkanModule);
+            }
 
             // NVAPI
             HMODULE nvapi64 = nullptr;
@@ -918,6 +917,7 @@ static void CheckQuirks()
     else if (exePathFilename == "nms.exe")
     {
         State::Instance().gameQuirks.set(GameQuirk::KernelBaseHooks);
+        State::Instance().gameQuirks |= GameQuirk::VulkanDLSSBarrierFixup;
         LOG_INFO("Enabling a quirk for No Man's Sky (Enable KernelBase hooks)");
     }
     else if (exePathFilename == "pathofexile.exe" || exePathFilename == "pathofexile_x64.exe" ||

--- a/OptiScaler/hooks/Kernel_Hooks.h
+++ b/OptiScaler/hooks/Kernel_Hooks.h
@@ -316,8 +316,7 @@ class KernelHooks
                     HookForVulkanVRAMSpoofing(module);
                 }
 
-                if (Config::Instance()->OverlayMenu.value_or_default())
-                    HooksVk::HookVk(module);
+                HooksVk::HookVk(module);
             }
             else
             {
@@ -705,8 +704,7 @@ class KernelHooks
                     HookForVulkanVRAMSpoofing(module);
                 }
 
-                if (Config::Instance()->OverlayMenu.value_or_default())
-                    HooksVk::HookVk(module);
+                HooksVk::HookVk(module);
             }
 
             return module;

--- a/OptiScaler/pch.h
+++ b/OptiScaler/pch.h
@@ -23,6 +23,8 @@
 #define SPDLOG_WCHAR_FILENAMES
 #include "spdlog/spdlog.h"
 
+#define VK_USE_PLATFORM_WIN32_KHR
+
 #define BUFFER_COUNT 4
 
 // Enables logging of DLSS NV Parameters


### PR DESCRIPTION
AMD drivers on the cards around RDNA2 didn't treat VK_IMAGE_LAYOUT_UNDEFINED in the same way Nvidia does. Doesn't seem like a bug, just a different way of handling an UB but we need to adjust.

Resolves: https://github.com/cdozdil/OptiScaler/issues/29