### PR TITLE
Locking cleanups

### DIFF
--- a/OptiScaler/OwnedMutex.h
+++ b/OptiScaler/OwnedMutex.h
@@ -8,7 +8,10 @@
 class OwnedMutex
 {
   private:
+    // shared* as basic mutex must only be unlocked by thread that locked it
     std::shared_mutex mtx;
+
+    // Written under mutex, read independently
     std::atomic<uint32_t> owner {}; // don't use 0
 
   public:
@@ -33,6 +36,7 @@ class OwnedMutex
         mtx.unlock();
     }
 
+    // Result is truthful only if and while locked
     uint32_t getOwner() { return owner.load(std::memory_order_seq_cst); }
 };
 
@@ -47,6 +51,8 @@ class OwnedLockGuard
     {
         _mutex.lock(_owner_id);
     }
+
+    OwnedLockGuard(const OwnedLockGuard&) = delete;
 
     ~OwnedLockGuard() { _mutex.unlockThis(_owner_id); }
 };

--- a/OptiScaler/hooks/HooksDx.cpp
+++ b/OptiScaler/hooks/HooksDx.cpp
@@ -242,10 +242,9 @@ static HRESULT hkFGPresent(void* This, UINT SyncInterval, UINT Flags)
                 // filter out posibly wrong measured high values
                 if (elapsedTimeMs < 100.0)
                 {
-                    State::Instance().frameTimeMutex.lock();
+                    std::lock_guard<std::mutex> lock(State::Instance().frameTimeMutex);
                     State::Instance().upscaleTimes.push_back(elapsedTimeMs);
                     State::Instance().upscaleTimes.pop_front();
-                    State::Instance().frameTimeMutex.unlock();
                 }
             }
             else
@@ -425,10 +424,9 @@ static HRESULT Present(IDXGISwapChain* pSwapChain, UINT SyncInterval, UINT Flags
             // filter out posibly wrong measured high values
             if (elapsedTimeMs < 100.0)
             {
-                State::Instance().frameTimeMutex.lock();
+                std::lock_guard<std::mutex> lock(State::Instance().frameTimeMutex);
                 State::Instance().upscaleTimes.push_back(elapsedTimeMs);
                 State::Instance().upscaleTimes.pop_front();
-                State::Instance().frameTimeMutex.unlock();
             }
         }
         else
@@ -466,10 +464,9 @@ static HRESULT Present(IDXGISwapChain* pSwapChain, UINT SyncInterval, UINT Flags
                     // filter out posibly wrong measured high values
                     if (elapsedTimeMs < 100.0)
                     {
-                        State::Instance().frameTimeMutex.lock();
+                        std::lock_guard<std::mutex> lock(State::Instance().frameTimeMutex);
                         State::Instance().upscaleTimes.push_back(elapsedTimeMs);
                         State::Instance().upscaleTimes.pop_front();
-                        State::Instance().frameTimeMutex.unlock();
                     }
                 }
             }

--- a/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
+++ b/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
@@ -1598,8 +1598,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(ID3D12GraphicsCom
         if (fg->Mutex.getOwner() == 2)
         {
             LOG_TRACE("Waiting for present!");
-            fg->Mutex.lock(4);
-            fg->Mutex.unlockThis(4);
+            OwnedLockGuard lock(fg->Mutex, 4);
         }
 
         bool allocatorReset = false;


### PR DESCRIPTION
Looking at the multi-thread locking I saw many raw lock & unlock calls. This PR uses lock guard objects where applicable and introduces an `optional<guard>` as a lazy man's `unique_lock`. Looking at the removed unlock conditions you will find the same condition that was used to conditionally lock in the first place.

I unnamed some temporary guard objects to avoid name clashes.

Some raw and even unmatched lock & unlock calls remain for some less trivial use cases.

I built and tested successfully with Cyberpunk 2077 on AMD with DLSS frame generation only. Yet please review carefully.